### PR TITLE
Rebrand to hypertrace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - checkout
 
-# TODO Task 'downloadDependencies' not found in root project 'traceable-otel-agent'.
+# TODO Task 'downloadDependencies' not found in root project 'hypertrace-otel-agent'.
 #      # Download and cache dependencies
 #      - restore_cache:
 #          keys:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![codecov](https://codecov.io/gh/Traceableai/opentelemetry-javaagent/branch/main/graph/badge.svg?token=MM5BVNGPKE)](https://codecov.io/gh/Traceableai/opentelemetry-javaagent)
 [![CircleCI](https://circleci.com/gh/Traceableai/opentelemetry-javaagent.svg?style=svg)](https://circleci.com/gh/Traceableai/opentelemetry-javaagent)
 
-# Traceable OpenTelemetry Java agent
+# Hypertrace OpenTelemetry Java agent
 
-Traceable distribution of [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation).
+Hypertrace distribution of [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation).
 
 In addition to the upstream this project adds these capabilities:
 * capture request and response headers
@@ -25,7 +25,7 @@ make build
 ## Run
 
 ```bash
-OTEL_EXPORTER=otlp java -agentlib:jdwp="transport=dt_socket,server=y,suspend=n,address=5000" -javaagent:${HOME}/projects/hypertrace/opentelemetry-java-agent/javaagent/build/libs/traceable-otel-javaagent-0.0.1-all.jar -jar app.jar
+OTEL_EXPORTER=otlp java -agentlib:jdwp="transport=dt_socket,server=y,suspend=n,address=5000" -javaagent:${HOME}/projects/hypertrace/opentelemetry-java-agent/javaagent/build/libs/hypertrace-agent-0.0.1-all.jar -jar app.jar
 ```
 
 ## Test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
     id("com.diffplug.spotless") version "5.2.0" apply false
 }
 
-description = "Traceable OpenTelemetry Java agent"
-group = "io.traceable.opentelemetry"
+description = "Hypertrace OpenTelemetry Java agent"
+group = "org.hypertrace.agent"
 version = "0.0.1"
 
 allprojects {

--- a/gradle/spotless.license.java
+++ b/gradle/spotless.license.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Traceable.ai Inc.
+ * Copyright The Hypertrace Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/servlet-3.0/src/main/java/org/hypertrace/agent/BufferingHttpServletRequest.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/org/hypertrace/agent/BufferingHttpServletRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Traceable.ai Inc.
+ * Copyright The Hypertrace Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.traceable.opentelemery.instrumentation.auto.servlet.bodycapture;
+package org.hypertrace.agent;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/instrumentation/servlet/servlet-3.0/src/main/java/org/hypertrace/agent/BufferingHttpServletResponse.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/org/hypertrace/agent/BufferingHttpServletResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Traceable.ai Inc.
+ * Copyright The Hypertrace Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.traceable.opentelemery.instrumentation.auto.servlet.bodycapture;
+package org.hypertrace.agent;
 
 import java.io.*;
 import java.net.HttpCookie;

--- a/instrumentation/servlet/servlet-3.0/src/main/java/org/hypertrace/agent/ByteBufferData.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/org/hypertrace/agent/ByteBufferData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Traceable.ai Inc.
+ * Copyright The Hypertrace Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.traceable.opentelemery.instrumentation.auto.servlet.bodycapture;
+package org.hypertrace.agent;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;

--- a/instrumentation/servlet/servlet-3.0/src/main/java/org/hypertrace/agent/CharBufferData.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/org/hypertrace/agent/CharBufferData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Traceable.ai Inc.
+ * Copyright The Hypertrace Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.traceable.opentelemery.instrumentation.auto.servlet.bodycapture;
+package org.hypertrace.agent;
 
 import java.util.Arrays;
 

--- a/instrumentation/servlet/servlet-3.0/src/main/java/org/hypertrace/agent/ExecutionBlocked.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/org/hypertrace/agent/ExecutionBlocked.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Traceable.ai Inc.
+ * Copyright The Hypertrace Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.traceable.opentelemery.instrumentation.auto.servlet.bodycapture;
+package org.hypertrace.agent;
 
 import net.bytebuddy.asm.Advice.OnMethodEnter;
 

--- a/instrumentation/servlet/servlet-3.0/src/main/java/org/hypertrace/agent/Servlet3BodyInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/org/hypertrace/agent/Servlet3BodyInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Traceable.ai Inc.
+ * Copyright The Hypertrace Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.traceable.opentelemery.instrumentation.auto.servlet.bodycapture;
+package org.hypertrace.agent;
 
 import static io.opentelemetry.instrumentation.auto.servlet.v3_0.Servlet3HttpServerTracer.TRACER;
 import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
     implementation("io.opentelemetry.instrumentation.auto", "opentelemetry-javaagent", version = "0.8.0", classifier = "all")
 }
 
-base.archivesBaseName = "traceable-agent"
+base.archivesBaseName = "hypertrace-agent"
 
 tasks {
     processResources {
@@ -24,7 +24,7 @@ tasks {
         mergeServiceFiles {
             include("inst/META-INF/services/*")
         }
-        // TODO we could order the Instrumenter services to guarantee that traceable instrumentation runs after OTEL
+        // TODO we could order the Instrumenter services to guarantee that hypertrace instrumentation runs after OTEL
 //        transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer())
         exclude("**/module-info.class")
         manifest {
@@ -32,9 +32,9 @@ tasks {
             attributes.put("Implementation-Version", project.version)
             // TODO set version from a property
             attributes.put("OpenTelemetry-Instrumentation-Version", "0.8.0")
-            attributes.put("Implementation-Vendor", "Traceable.ai")
+            attributes.put("Implementation-Vendor", "Hypertrace.org")
             // TODO set to Github repository URL
-            attributes.put("Implementation-Url", "https://traceable.ai")
+            attributes.put("Implementation-Url", "https://hypertrace.org")
             attributes.put("Main-Class",    "io.opentelemetry.javaagent.OpenTelemetryAgent")
             attributes.put("Agent-Class",   "io.opentelemetry.javaagent.OpenTelemetryAgent")
             attributes.put("Premain-Class", "io.opentelemetry.javaagent.OpenTelemetryAgent")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "traceable-otel-agent"
+rootProject.name = "hypertrace-otel-agent"
 
 include(":javaagent")
 include("instrumentation")

--- a/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/AbstractSmokeTest.java
+++ b/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/AbstractSmokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Traceable.ai Inc.
+ * Copyright The Hypertrace Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.traceable.opentelemetry.instrumentation.smoketest;
+package org.hypertrace.agent.smoketest;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;

--- a/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/OpenTelemetryCollector.java
+++ b/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/OpenTelemetryCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Traceable.ai Inc.
+ * Copyright The Hypertrace Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.traceable.opentelemetry.instrumentation.smoketest;
+package org.hypertrace.agent.smoketest;
 
 import java.util.Collections;
 import java.util.Set;

--- a/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/OpenTelemetryStorage.java
+++ b/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/OpenTelemetryStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Traceable.ai Inc.
+ * Copyright The Hypertrace Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.traceable.opentelemetry.instrumentation.smoketest;
+package org.hypertrace.agent.smoketest;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;

--- a/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/SpringBootTest.java
+++ b/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/SpringBootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Traceable.ai Inc.
+ * Copyright The Hypertrace Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.traceable.opentelemetry.instrumentation.smoketest;
+package org.hypertrace.agent.smoketest;
 
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import java.io.IOException;


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Resolves #6 

The project will be moved to Hypertrace org, hence renaming.