### PR TITLE
Move instrumentationMuzzle configurations to javaagent-tooling

### DIFF
--- a/instrumentation/servlet/servlet-2.3/build.gradle.kts
+++ b/instrumentation/servlet/servlet-2.3/build.gradle.kts
@@ -23,12 +23,10 @@ afterEvaluate{
         transformation(closureOf<net.bytebuddy.build.gradle.Transformation> {
             setTasks(setOf("compileJava", "compileScala", "compileKotlin"))
             plugin = "io.opentelemetry.javaagent.tooling.muzzle.collector.MuzzleCodeGenerationPlugin"
-            setClassPath(instrumentationMuzzle + configurations.runtimeClasspath + sourceSets["main"].output)
+            setClassPath(project(":javaagent-tooling").configurations["instrumentationMuzzle"] + configurations.runtimeClasspath + sourceSets["main"].output)
         })
     }
 }
-
-val instrumentationMuzzle by configurations.creating
 
 dependencies {
     api(project(":blocking"))
@@ -38,15 +36,6 @@ dependencies {
     implementation("net.bytebuddy:byte-buddy:1.10.10")
 
     implementation("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-servlet-2.2:0.9.0")
-
-    instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:0.9.0")
-    instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap:0.9.0")
-    instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-api:0.9.0")
-    instrumentationMuzzle("net.bytebuddy:byte-buddy:1.10.10")
-    instrumentationMuzzle("net.bytebuddy:byte-buddy-agent:1.10.10")
-    instrumentationMuzzle("com.blogspot.mydailyjava:weak-lock-free:0.15")
-    instrumentationMuzzle("com.google.auto.service:auto-service:1.0-rc7")
-    instrumentationMuzzle("org.slf4j:slf4j-api:1.7.30")
 
     testImplementation(project(":testing-common"))
     testImplementation("org.eclipse.jetty:jetty-server:7.5.4.v20111024")

--- a/instrumentation/servlet/servlet-3.0/build.gradle.kts
+++ b/instrumentation/servlet/servlet-3.0/build.gradle.kts
@@ -24,12 +24,10 @@ afterEvaluate{
         transformation(closureOf<net.bytebuddy.build.gradle.Transformation> {
             setTasks(kotlin.collections.setOf("compileJava", "compileScala", "compileKotlin"))
             plugin = "io.opentelemetry.javaagent.tooling.muzzle.collector.MuzzleCodeGenerationPlugin"
-            setClassPath(instrumentationMuzzle + configurations.runtimeClasspath + sourceSets["main"].output)
+            setClassPath(project(":javaagent-tooling").configurations["instrumentationMuzzle"] + configurations.runtimeClasspath + sourceSets["main"].output)
         })
     }
 }
-
-val instrumentationMuzzle by configurations.creating
 
 dependencies {
     api(project(":blocking"))
@@ -39,15 +37,6 @@ dependencies {
     implementation("net.bytebuddy:byte-buddy:1.10.10")
 
     implementation("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-servlet-3.0:0.9.0")
-
-    instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:0.9.0")
-    instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap:0.9.0")
-    instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-api:0.9.0")
-    instrumentationMuzzle("net.bytebuddy:byte-buddy:1.10.10")
-    instrumentationMuzzle("net.bytebuddy:byte-buddy-agent:1.10.10")
-    instrumentationMuzzle("com.blogspot.mydailyjava:weak-lock-free:0.15")
-    instrumentationMuzzle("com.google.auto.service:auto-service:1.0-rc7")
-    instrumentationMuzzle("org.slf4j:slf4j-api:1.7.30")
 
     testImplementation(project(":testing-common"))
     testImplementation("org.eclipse.jetty:jetty-server:8.1.22.v20160922")

--- a/instrumentation/servlet/servlet-3.1/build.gradle.kts
+++ b/instrumentation/servlet/servlet-3.1/build.gradle.kts
@@ -25,12 +25,10 @@ afterEvaluate{
         transformation(closureOf<net.bytebuddy.build.gradle.Transformation> {
             setTasks(setOf("compileJava", "compileScala", "compileKotlin"))
             plugin = "io.opentelemetry.javaagent.tooling.muzzle.collector.MuzzleCodeGenerationPlugin"
-            setClassPath(instrumentationMuzzle + configurations.runtimeClasspath + sourceSets["main"].output)
+            setClassPath(project(":javaagent-tooling").configurations["instrumentationMuzzle"] + configurations.runtimeClasspath + sourceSets["main"].output)
         })
     }
 }
-
-val instrumentationMuzzle by configurations.creating
 
 dependencies {
     api(project(":blocking"))
@@ -40,15 +38,6 @@ dependencies {
     implementation("net.bytebuddy:byte-buddy:1.10.10")
 
     implementation("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-servlet-3.0:0.9.0")
-
-    instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:0.9.0")
-    instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap:0.9.0")
-    instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-api:0.9.0")
-    instrumentationMuzzle("net.bytebuddy:byte-buddy:1.10.10")
-    instrumentationMuzzle("net.bytebuddy:byte-buddy-agent:1.10.10")
-    instrumentationMuzzle("com.blogspot.mydailyjava:weak-lock-free:0.15")
-    instrumentationMuzzle("com.google.auto.service:auto-service:1.0-rc7")
-    instrumentationMuzzle("org.slf4j:slf4j-api:1.7.30")
 
     testImplementation(project(":testing-common"))
     testImplementation("org.eclipse.jetty:jetty-server:9.4.32.v20200930")

--- a/instrumentation/spark-web-framework-2.3/build.gradle.kts
+++ b/instrumentation/spark-web-framework-2.3/build.gradle.kts
@@ -19,12 +19,10 @@ afterEvaluate{
         transformation(closureOf<net.bytebuddy.build.gradle.Transformation> {
             setTasks(kotlin.collections.setOf("compileJava", "compileScala", "compileKotlin"))
             plugin = "io.opentelemetry.javaagent.tooling.muzzle.collector.MuzzleCodeGenerationPlugin"
-            setClassPath(instrumentationMuzzle + configurations.runtimeClasspath + sourceSets["main"].output + project(":instrumentation:servlet:servlet-3.1").sourceSets["main"].output)
+            setClassPath(project(":javaagent-tooling").configurations["instrumentationMuzzle"] + configurations.runtimeClasspath + sourceSets["main"].output + project(":instrumentation:servlet:servlet-3.1").sourceSets["main"].output)
         })
     }
 }
-
-val instrumentationMuzzle by configurations.creating
 
 dependencies {
     api(project(":blocking"))
@@ -36,15 +34,6 @@ dependencies {
     implementation("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-spark-web-framework-2.3:0.9.0")
     implementation("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-servlet-3.0:0.9.0")
     implementation("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-jetty-8.0:0.9.0")
-
-    instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:0.9.0")
-    instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap:0.9.0")
-    instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-api:0.9.0")
-    instrumentationMuzzle("net.bytebuddy:byte-buddy:1.10.10")
-    instrumentationMuzzle("net.bytebuddy:byte-buddy-agent:1.10.10")
-    instrumentationMuzzle("com.blogspot.mydailyjava:weak-lock-free:0.15")
-    instrumentationMuzzle("com.google.auto.service:auto-service:1.0-rc7")
-    instrumentationMuzzle("org.slf4j:slf4j-api:1.7.30")
 
     testImplementation(project(":testing-common"))
     testImplementation("com.sparkjava:spark-core:2.3")

--- a/javaagent-tooling/build.gradle.kts
+++ b/javaagent-tooling/build.gradle.kts
@@ -4,8 +4,17 @@ plugins {
     `java-library`
 }
 
-dependencies{
-    implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:0.9.0")
-    implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-api:0.9.0")
+val instrumentationMuzzle by configurations.creating {
+    extendsFrom(configurations.implementation.get())
 }
 
+dependencies {
+    implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:0.9.0")
+    implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-api:0.9.0")
+    instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap:0.9.0")
+    instrumentationMuzzle("net.bytebuddy:byte-buddy:1.10.10")
+    instrumentationMuzzle("net.bytebuddy:byte-buddy-agent:1.10.10")
+    instrumentationMuzzle("com.blogspot.mydailyjava:weak-lock-free:0.15")
+    instrumentationMuzzle("com.google.auto.service:auto-service:1.0-rc7")
+    instrumentationMuzzle("org.slf4j:slf4j-api:1.7.30")
+}


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

This simplifies the configuration as the muzzle classpath will be defined in a single place.