### PR TITLE
Define dependency on blocking in instrumentation parent

### DIFF
--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -11,6 +11,7 @@ subprojects {
 
         implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:0.9.0")
         implementation(project(":javaagent-core"))
+        implementation(project(":blocking"))
     }
 }
 

--- a/instrumentation/servlet/servlet-2.3/build.gradle.kts
+++ b/instrumentation/servlet/servlet-2.3/build.gradle.kts
@@ -29,7 +29,6 @@ afterEvaluate{
 }
 
 dependencies {
-    api(project(":blocking"))
     api(project(":instrumentation:servlet:servlet-common"))
 
     compileOnly("javax.servlet:servlet-api:2.3")

--- a/instrumentation/servlet/servlet-3.0/build.gradle.kts
+++ b/instrumentation/servlet/servlet-3.0/build.gradle.kts
@@ -30,7 +30,6 @@ afterEvaluate{
 }
 
 dependencies {
-    api(project(":blocking"))
     api(project(":instrumentation:servlet:servlet-common"))
 
     compileOnly("javax.servlet:javax.servlet-api:3.0.1")

--- a/instrumentation/servlet/servlet-3.1/build.gradle.kts
+++ b/instrumentation/servlet/servlet-3.1/build.gradle.kts
@@ -31,7 +31,6 @@ afterEvaluate{
 }
 
 dependencies {
-    api(project(":blocking"))
     api(project(":instrumentation:servlet:servlet-common"))
 
     compileOnly("javax.servlet:javax.servlet-api:3.1.0")

--- a/instrumentation/spark-web-framework-2.3/build.gradle.kts
+++ b/instrumentation/spark-web-framework-2.3/build.gradle.kts
@@ -25,7 +25,6 @@ afterEvaluate{
 }
 
 dependencies {
-    api(project(":blocking"))
     api(project(":instrumentation:servlet:servlet-3.1"))
 
     compileOnly("com.sparkjava:spark-core:2.3")


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

As all instrumentation modules depend on blocking it makes sense to move it to the parent.