### PR TITLE
Add http prefix for HTTP attributes

### DIFF
--- a/instrumentation/servlet/servlet-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v2_3/Servlet2BodyInstrumentation.java
+++ b/instrumentation/servlet/servlet-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v2_3/Servlet2BodyInstrumentation.java
@@ -160,7 +160,7 @@ public class Servlet2BodyInstrumentation extends Instrumenter.Default {
         String headerName = headerNames.nextElement();
         String headerValue = httpRequest.getHeader(headerName);
         currentSpan.setAttribute(
-            HypertraceSemanticAttributes.requestHeader(headerName), headerValue);
+            HypertraceSemanticAttributes.httpRequestHeader(headerName), headerValue);
         headers.put(headerName, headerValue);
       }
       BlockingResult blockingResult = BlockingProvider.getBlockingEvaluator().evaluate(headers);
@@ -198,14 +198,15 @@ public class Servlet2BodyInstrumentation extends Instrumenter.Default {
           String headerName = nameToHeadersEntry.getKey();
           for (String headerValue : nameToHeadersEntry.getValue()) {
             currentSpan.setAttribute(
-                HypertraceSemanticAttributes.responseHeader(headerName), headerValue);
+                HypertraceSemanticAttributes.httpResponseHeader(headerName), headerValue);
           }
         }
         // Bodies are captured at the end after all user processing.
         currentSpan.setAttribute(
-            HypertraceSemanticAttributes.REQUEST_BODY, bufferingRequest.getBufferedBodyAsString());
+            HypertraceSemanticAttributes.HTTP_REQUEST_BODY,
+            bufferingRequest.getBufferedBodyAsString());
         currentSpan.setAttribute(
-            HypertraceSemanticAttributes.RESPONSE_BODY, bufferingResponse.getBufferAsString());
+            HypertraceSemanticAttributes.HTTP_RESPONSE_BODY, bufferingResponse.getBufferAsString());
       }
     }
   }

--- a/instrumentation/servlet/servlet-2.3/src/test/java/io/opentelemetry/instrumentation/hypertrace/servlet/v2_3/Servlet23Test.java
+++ b/instrumentation/servlet/servlet-2.3/src/test/java/io/opentelemetry/instrumentation/hypertrace/servlet/v2_3/Servlet23Test.java
@@ -63,19 +63,21 @@ public class Servlet23Test extends AbstractInstrumenterTest {
     Assertions.assertEquals(1, spans.size());
     SpanData spanData = spans.get(0);
     Assertions.assertEquals(
-        requestBody, spanData.getAttributes().get(HypertraceSemanticAttributes.REQUEST_BODY));
+        requestBody, spanData.getAttributes().get(HypertraceSemanticAttributes.HTTP_REQUEST_BODY));
     Assertions.assertEquals(
         requestHeaderValue,
-        spanData.getAttributes().get(HypertraceSemanticAttributes.requestHeader(requestHeader)));
+        spanData
+            .getAttributes()
+            .get(HypertraceSemanticAttributes.httpRequestHeader(requestHeader)));
 
     Assertions.assertEquals(
         TestServlet.RESPONSE_BODY,
-        spanData.getAttributes().get(HypertraceSemanticAttributes.RESPONSE_BODY));
+        spanData.getAttributes().get(HypertraceSemanticAttributes.HTTP_RESPONSE_BODY));
     Assertions.assertEquals(
         TestServlet.RESPONSE_HEADER_VALUE,
         spanData
             .getAttributes()
-            .get(HypertraceSemanticAttributes.responseHeader(TestServlet.RESPONSE_HEADER)));
+            .get(HypertraceSemanticAttributes.httpResponseHeader(TestServlet.RESPONSE_HEADER)));
     server.stop();
   }
 }

--- a/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_0/Servlet30BodyInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_0/Servlet30BodyInstrumentation.java
@@ -159,7 +159,7 @@ public class Servlet30BodyInstrumentation extends Instrumenter.Default {
         String headerName = headerNames.nextElement();
         String headerValue = httpRequest.getHeader(headerName);
         currentSpan.setAttribute(
-            HypertraceSemanticAttributes.requestHeader(headerName), headerValue);
+            HypertraceSemanticAttributes.httpRequestHeader(headerName), headerValue);
         headers.put(headerName, headerValue);
       }
       BlockingResult blockingResult = BlockingProvider.getBlockingEvaluator().evaluate(headers);
@@ -208,14 +208,15 @@ public class Servlet30BodyInstrumentation extends Instrumenter.Default {
           for (String headerName : bufferingResponse.getHeaderNames()) {
             String headerValue = bufferingResponse.getHeader(headerName);
             currentSpan.setAttribute(
-                HypertraceSemanticAttributes.responseHeader(headerName), headerValue);
+                HypertraceSemanticAttributes.httpResponseHeader(headerName), headerValue);
           }
           // Bodies are captured at the end after all user processing.
           currentSpan.setAttribute(
-              HypertraceSemanticAttributes.REQUEST_BODY,
+              HypertraceSemanticAttributes.HTTP_REQUEST_BODY,
               bufferingRequest.getBufferedBodyAsString());
           currentSpan.setAttribute(
-              HypertraceSemanticAttributes.RESPONSE_BODY, bufferingResponse.getBufferAsString());
+              HypertraceSemanticAttributes.HTTP_RESPONSE_BODY,
+              bufferingResponse.getBufferAsString());
         }
       }
     }

--- a/instrumentation/servlet/servlet-3.0/src/test/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_0/Servlet30Test.java
+++ b/instrumentation/servlet/servlet-3.0/src/test/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_0/Servlet30Test.java
@@ -64,19 +64,21 @@ public class Servlet30Test extends AbstractInstrumenterTest {
     Assertions.assertEquals(1, spans.size());
     SpanData spanData = spans.get(0);
     Assertions.assertEquals(
-        requestBody, spanData.getAttributes().get(HypertraceSemanticAttributes.REQUEST_BODY));
+        requestBody, spanData.getAttributes().get(HypertraceSemanticAttributes.HTTP_REQUEST_BODY));
     Assertions.assertEquals(
         requestHeaderValue,
-        spanData.getAttributes().get(HypertraceSemanticAttributes.requestHeader(requestHeader)));
+        spanData
+            .getAttributes()
+            .get(HypertraceSemanticAttributes.httpRequestHeader(requestHeader)));
 
     Assertions.assertEquals(
         TestServlet.RESPONSE_BODY,
-        spanData.getAttributes().get(HypertraceSemanticAttributes.RESPONSE_BODY));
+        spanData.getAttributes().get(HypertraceSemanticAttributes.HTTP_RESPONSE_BODY));
     Assertions.assertEquals(
         TestServlet.RESPONSE_HEADER_VALUE,
         spanData
             .getAttributes()
-            .get(HypertraceSemanticAttributes.responseHeader(TestServlet.RESPONSE_HEADER)));
+            .get(HypertraceSemanticAttributes.httpResponseHeader(TestServlet.RESPONSE_HEADER)));
     server.stop();
   }
 }

--- a/instrumentation/servlet/servlet-3.1/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_1/Servlet31BodyInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.1/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_1/Servlet31BodyInstrumentation.java
@@ -156,7 +156,7 @@ public class Servlet31BodyInstrumentation extends Instrumenter.Default {
         String headerName = headerNames.nextElement();
         String headerValue = httpRequest.getHeader(headerName);
         currentSpan.setAttribute(
-            HypertraceSemanticAttributes.requestHeader(headerName), headerValue);
+            HypertraceSemanticAttributes.httpRequestHeader(headerName), headerValue);
         headers.put(headerName, headerValue);
       }
       BlockingResult blockingResult = BlockingProvider.getBlockingEvaluator().evaluate(headers);
@@ -205,14 +205,15 @@ public class Servlet31BodyInstrumentation extends Instrumenter.Default {
           for (String headerName : bufferingResponse.getHeaderNames()) {
             String headerValue = bufferingResponse.getHeader(headerName);
             currentSpan.setAttribute(
-                HypertraceSemanticAttributes.responseHeader(headerName), headerValue);
+                HypertraceSemanticAttributes.httpResponseHeader(headerName), headerValue);
           }
           // Bodies are captured at the end after all user processing.
           currentSpan.setAttribute(
-              HypertraceSemanticAttributes.REQUEST_BODY,
+              HypertraceSemanticAttributes.HTTP_REQUEST_BODY,
               bufferingRequest.getBufferedBodyAsString());
           currentSpan.setAttribute(
-              HypertraceSemanticAttributes.RESPONSE_BODY, bufferingResponse.getBufferAsString());
+              HypertraceSemanticAttributes.HTTP_RESPONSE_BODY,
+              bufferingResponse.getBufferAsString());
         }
       }
     }

--- a/instrumentation/servlet/servlet-3.1/src/test/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_1/Servlet31Test.java
+++ b/instrumentation/servlet/servlet-3.1/src/test/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_1/Servlet31Test.java
@@ -65,19 +65,21 @@ public class Servlet31Test extends AbstractInstrumenterTest {
     Assertions.assertEquals(1, spans.size());
     SpanData spanData = spans.get(0);
     Assertions.assertEquals(
-        requestBody, spanData.getAttributes().get(HypertraceSemanticAttributes.REQUEST_BODY));
+        requestBody, spanData.getAttributes().get(HypertraceSemanticAttributes.HTTP_REQUEST_BODY));
     Assertions.assertEquals(
         requestHeaderValue,
-        spanData.getAttributes().get(HypertraceSemanticAttributes.requestHeader(requestHeader)));
+        spanData
+            .getAttributes()
+            .get(HypertraceSemanticAttributes.httpRequestHeader(requestHeader)));
 
     Assertions.assertEquals(
         TestServlet.RESPONSE_BODY,
-        spanData.getAttributes().get(HypertraceSemanticAttributes.RESPONSE_BODY));
+        spanData.getAttributes().get(HypertraceSemanticAttributes.HTTP_RESPONSE_BODY));
     Assertions.assertEquals(
         TestServlet.RESPONSE_HEADER_VALUE,
         spanData
             .getAttributes()
-            .get(HypertraceSemanticAttributes.responseHeader(TestServlet.RESPONSE_HEADER)));
+            .get(HypertraceSemanticAttributes.httpResponseHeader(TestServlet.RESPONSE_HEADER)));
     server.stop();
   }
 }

--- a/instrumentation/spark-web-framework-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/sparkjava/SparkJavaBodyInstrumentation.java
+++ b/instrumentation/spark-web-framework-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/sparkjava/SparkJavaBodyInstrumentation.java
@@ -125,7 +125,7 @@ public class SparkJavaBodyInstrumentation extends Instrumenter.Default {
         String headerName = headerNames.nextElement();
         String headerValue = httpRequest.getHeader(headerName);
         currentSpan.setAttribute(
-            HypertraceSemanticAttributes.requestHeader(headerName), headerValue);
+            HypertraceSemanticAttributes.httpRequestHeader(headerName), headerValue);
         headers.put(headerName, headerValue);
       }
       BlockingResult blockingResult = BlockingProvider.getBlockingEvaluator().evaluate(headers);
@@ -156,13 +156,14 @@ public class SparkJavaBodyInstrumentation extends Instrumenter.Default {
       for (String headerName : bufferingResponse.getHeaderNames()) {
         String headerValue = bufferingResponse.getHeader(headerName);
         currentSpan.setAttribute(
-            HypertraceSemanticAttributes.responseHeader(headerName), headerValue);
+            HypertraceSemanticAttributes.httpResponseHeader(headerName), headerValue);
       }
       // Bodies are captured at the end after all user processing.
       currentSpan.setAttribute(
-          HypertraceSemanticAttributes.REQUEST_BODY, bufferingRequest.getBufferedBodyAsString());
+          HypertraceSemanticAttributes.HTTP_REQUEST_BODY,
+          bufferingRequest.getBufferedBodyAsString());
       currentSpan.setAttribute(
-          HypertraceSemanticAttributes.RESPONSE_BODY, bufferingResponse.getBufferAsString());
+          HypertraceSemanticAttributes.HTTP_RESPONSE_BODY, bufferingResponse.getBufferAsString());
       return null;
     }
   }

--- a/instrumentation/spark-web-framework-2.3/src/test/java/io/opentelemetry/instrumentation/hypertrace/sparkjava/SparkJavaBodyCaptureTest.java
+++ b/instrumentation/spark-web-framework-2.3/src/test/java/io/opentelemetry/instrumentation/hypertrace/sparkjava/SparkJavaBodyCaptureTest.java
@@ -89,16 +89,21 @@ public class SparkJavaBodyCaptureTest extends AbstractInstrumenterTest {
     Assertions.assertEquals(1, spans.size());
     SpanData spanData = spans.get(0);
     Assertions.assertEquals(
-        REQUEST_BODY, spanData.getAttributes().get(HypertraceSemanticAttributes.REQUEST_BODY));
+        REQUEST_BODY, spanData.getAttributes().get(HypertraceSemanticAttributes.HTTP_REQUEST_BODY));
     Assertions.assertEquals(
         REQUEST_HEADER_VALUE,
-        spanData.getAttributes().get(HypertraceSemanticAttributes.requestHeader(REQUEST_HEADER)));
+        spanData
+            .getAttributes()
+            .get(HypertraceSemanticAttributes.httpRequestHeader(REQUEST_HEADER)));
 
     Assertions.assertEquals(
-        RESPONSE_BODY, spanData.getAttributes().get(HypertraceSemanticAttributes.RESPONSE_BODY));
+        RESPONSE_BODY,
+        spanData.getAttributes().get(HypertraceSemanticAttributes.HTTP_RESPONSE_BODY));
     Assertions.assertEquals(
         RESPONSE_HEADER_VALUE,
-        spanData.getAttributes().get(HypertraceSemanticAttributes.responseHeader(RESPONSE_HEADER)));
+        spanData
+            .getAttributes()
+            .get(HypertraceSemanticAttributes.httpResponseHeader(RESPONSE_HEADER)));
   }
 
   @Test
@@ -119,13 +124,17 @@ public class SparkJavaBodyCaptureTest extends AbstractInstrumenterTest {
     SpanData spanData = spans.get(0);
     Assertions.assertEquals(
         REQUEST_HEADER_VALUE,
-        spanData.getAttributes().get(HypertraceSemanticAttributes.requestHeader(REQUEST_HEADER)));
+        spanData
+            .getAttributes()
+            .get(HypertraceSemanticAttributes.httpRequestHeader(REQUEST_HEADER)));
 
     Assertions.assertEquals(
         "<html><body><h2>500 Internal Error</h2></body></html>",
-        spanData.getAttributes().get(HypertraceSemanticAttributes.RESPONSE_BODY));
+        spanData.getAttributes().get(HypertraceSemanticAttributes.HTTP_RESPONSE_BODY));
     Assertions.assertEquals(
         RESPONSE_HEADER_VALUE,
-        spanData.getAttributes().get(HypertraceSemanticAttributes.responseHeader(RESPONSE_HEADER)));
+        spanData
+            .getAttributes()
+            .get(HypertraceSemanticAttributes.httpResponseHeader(RESPONSE_HEADER)));
   }
 }

--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/HypertraceSemanticAttributes.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/HypertraceSemanticAttributes.java
@@ -24,17 +24,17 @@ import io.opentelemetry.common.AttributeKey;
 public class HypertraceSemanticAttributes {
   private HypertraceSemanticAttributes() {}
 
-  public static AttributeKey<String> requestHeader(String header) {
-    return stringKey("request.header." + header);
+  public static AttributeKey<String> httpRequestHeader(String header) {
+    return stringKey("http.request.header." + header);
   }
 
-  public static AttributeKey<String> responseHeader(String header) {
-    return stringKey("response.header." + header);
+  public static AttributeKey<String> httpResponseHeader(String header) {
+    return stringKey("http.response.header." + header);
   }
 
-  public static final AttributeKey<String> REQUEST_BODY = stringKey("request.body");
+  public static final AttributeKey<String> HTTP_REQUEST_BODY = stringKey("http.request.body");
 
-  public static final AttributeKey<String> RESPONSE_BODY = stringKey("response.body");
+  public static final AttributeKey<String> HTTP_RESPONSE_BODY = stringKey("http.response.body");
 
   public static final AttributeKey<Boolean> OPA_RESULT = booleanKey("hypertrace.opa.result");
 


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

The platform expects HTTP attributes be scoped under `http` prefix.