### PR TITLE
Configure CI to publish release on Github with the final jar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
 
   release-github-publish:
     docker:
-      - image: cibuilds/github:0.10
+      - image: cibuilds/github:0.13
     steps:
       - attach_workspace:
           at: ./artifacts


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <pavol.loffay@traceable.ai>