### PR TITLE
Remove core OTEL helper classes from injection

### DIFF
--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/instrumentation/hypertrace/grpc/v1_5/client/GrpcClientBodyInstrumentation.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/instrumentation/hypertrace/grpc/v1_5/client/GrpcClientBodyInstrumentation.java
@@ -47,17 +47,6 @@ public class GrpcClientBodyInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "io.opentelemetry.instrumentation.grpc.v1_5.common.GrpcHelper",
-      "io.opentelemetry.instrumentation.grpc.v1_5.client.GrpcClientTracer",
-      "io.opentelemetry.instrumentation.grpc.v1_5.client.GrpcInjectAdapter",
-      "io.opentelemetry.instrumentation.grpc.v1_5.client.TracingClientInterceptor",
-      "io.opentelemetry.instrumentation.grpc.v1_5.client.TracingClientInterceptor$TracingClientCall",
-      "io.opentelemetry.instrumentation.grpc.v1_5.client.TracingClientInterceptor$TracingClientCallListener",
-      "io.opentelemetry.instrumentation.grpc.v1_5.server.GrpcExtractAdapter",
-      "io.opentelemetry.instrumentation.grpc.v1_5.server.GrpcServerTracer",
-      "io.opentelemetry.instrumentation.grpc.v1_5.server.TracingServerInterceptor",
-      "io.opentelemetry.instrumentation.grpc.v1_5.server.TracingServerInterceptor$TracingServerCall",
-      "io.opentelemetry.instrumentation.grpc.v1_5.server.TracingServerInterceptor$TracingServerCallListener",
       "io.opentelemetry.instrumentation.hypertrace.grpc.v1_5.GrpcTracer",
       "io.opentelemetry.instrumentation.hypertrace.grpc.v1_5.GrpcSpanDecorator",
       "io.opentelemetry.instrumentation.hypertrace.grpc.v1_5.InstrumentationName",

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/instrumentation/hypertrace/grpc/v1_5/client/GrpcClientInterceptor.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/instrumentation/hypertrace/grpc/v1_5/client/GrpcClientInterceptor.java
@@ -25,16 +25,17 @@ import io.grpc.ForwardingClientCall;
 import io.grpc.ForwardingClientCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.instrumentation.hypertrace.grpc.v1_5.GrpcSpanDecorator;
-import io.opentelemetry.instrumentation.hypertrace.grpc.v1_5.GrpcTracer;
 import io.opentelemetry.instrumentation.hypertrace.grpc.v1_5.InstrumentationName;
 import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Tracer;
 import org.hypertrace.agent.core.HypertraceConfig;
 import org.hypertrace.agent.core.HypertraceSemanticAttributes;
 
 public class GrpcClientInterceptor implements ClientInterceptor {
 
-  private static final GrpcTracer TRACER = new GrpcTracer();
+  private static final Tracer TRACER = OpenTelemetry.getTracer("org.hypertrace.agent.grpc");
 
   @Override
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/instrumentation/hypertrace/grpc/v1_5/server/GrpcServerBodyInstrumentation.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/instrumentation/hypertrace/grpc/v1_5/server/GrpcServerBodyInstrumentation.java
@@ -45,17 +45,6 @@ public class GrpcServerBodyInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "io.opentelemetry.instrumentation.grpc.v1_5.common.GrpcHelper",
-      "io.opentelemetry.instrumentation.grpc.v1_5.client.GrpcClientTracer",
-      "io.opentelemetry.instrumentation.grpc.v1_5.client.GrpcInjectAdapter",
-      "io.opentelemetry.instrumentation.grpc.v1_5.client.TracingClientInterceptor",
-      "io.opentelemetry.instrumentation.grpc.v1_5.client.TracingClientInterceptor$TracingClientCall",
-      "io.opentelemetry.instrumentation.grpc.v1_5.client.TracingClientInterceptor$TracingClientCallListener",
-      "io.opentelemetry.instrumentation.grpc.v1_5.server.GrpcExtractAdapter",
-      "io.opentelemetry.instrumentation.grpc.v1_5.server.GrpcServerTracer",
-      "io.opentelemetry.instrumentation.grpc.v1_5.server.TracingServerInterceptor",
-      "io.opentelemetry.instrumentation.grpc.v1_5.server.TracingServerInterceptor$TracingServerCall",
-      "io.opentelemetry.instrumentation.grpc.v1_5.server.TracingServerInterceptor$TracingServerCallListener",
       "org.hypertrace.agent.filter.FilterProvider",
       "org.hypertrace.agent.filter.FilterEvaluator",
       "org.hypertrace.agent.filter.FilterResult",

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/instrumentation/hypertrace/grpc/v1_5/server/GrpcServerInterceptor.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/instrumentation/hypertrace/grpc/v1_5/server/GrpcServerInterceptor.java
@@ -24,11 +24,12 @@ import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.instrumentation.hypertrace.grpc.v1_5.GrpcSpanDecorator;
-import io.opentelemetry.instrumentation.hypertrace.grpc.v1_5.GrpcTracer;
 import io.opentelemetry.instrumentation.hypertrace.grpc.v1_5.InstrumentationName;
 import io.opentelemetry.instrumentation.hypertrace.grpc.v1_5.server.GrpcServerInterceptor.TracingServerCall.TracingServerCallListener;
 import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Tracer;
 import java.util.Map;
 import org.hypertrace.agent.core.HypertraceConfig;
 import org.hypertrace.agent.core.HypertraceSemanticAttributes;
@@ -37,7 +38,7 @@ import org.hypertrace.agent.filter.FilterResult;
 
 public class GrpcServerInterceptor implements ServerInterceptor {
 
-  private static final GrpcTracer TRACER = new GrpcTracer();
+  private static final Tracer TRACER = OpenTelemetry.getTracer("org.hypertrace.agent.grpc");
 
   @Override
   public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(

--- a/instrumentation/okhttp/okhttp-3.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/okhttp/v3_0/OkHttpTracingInterceptor.java
+++ b/instrumentation/okhttp/okhttp-3.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/okhttp/v3_0/OkHttpTracingInterceptor.java
@@ -16,9 +16,10 @@
 
 package io.opentelemetry.instrumentation.hypertrace.okhttp.v3_0;
 
+import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.common.AttributeKey;
-import io.opentelemetry.javaagent.instrumentation.okhttp.v3_0.OkHttpClientTracer;
 import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Tracer;
 import java.io.IOException;
 import java.util.function.Function;
 import okhttp3.Headers;
@@ -38,7 +39,7 @@ import org.slf4j.LoggerFactory;
 public class OkHttpTracingInterceptor implements Interceptor {
   private static final Logger log = LoggerFactory.getLogger(OkHttpTracingInterceptor.class);
 
-  private static final OkHttpClientTracer TRACER = OkHttpClientTracer.TRACER;
+  private static final Tracer TRACER = OpenTelemetry.getTracer("org.hypertrace.agent.okhttp");
 
   @Override
   public Response intercept(Chain chain) throws IOException {

--- a/instrumentation/servlet/servlet-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v2_3/InstrumentationName.java
+++ b/instrumentation/servlet/servlet-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v2_3/InstrumentationName.java
@@ -16,6 +16,10 @@
 
 package io.opentelemetry.instrumentation.hypertrace.servlet.v2_3;
 
+import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.trace.Tracer;
+
 public class InstrumentationName {
   public static final String[] INSTRUMENTATION_NAME = {"servlet", "servlet-2"};
+  public static final Tracer TRACER = OpenTelemetry.getTracer("org.hypertrace.agent.servlet");
 }

--- a/instrumentation/servlet/servlet-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v2_3/Servlet2BodyInstrumentation.java
+++ b/instrumentation/servlet/servlet-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v2_3/Servlet2BodyInstrumentation.java
@@ -16,7 +16,6 @@
 
 package io.opentelemetry.instrumentation.hypertrace.servlet.v2_3;
 
-import static io.opentelemetry.javaagent.instrumentation.servlet.v2_2.Servlet2HttpServerTracer.TRACER;
 import static io.opentelemetry.javaagent.tooling.ClassLoaderMatcher.hasClassesNamed;
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementMatchers.safeHasSuperType;
 import static io.opentelemetry.javaagent.tooling.matcher.NameMatchers.namedOneOf;
@@ -87,10 +86,6 @@ public class Servlet2BodyInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "io.opentelemetry.instrumentation.servlet.HttpServletRequestGetter",
-      "io.opentelemetry.instrumentation.servlet.ServletHttpServerTracer",
-      "io.opentelemetry.javaagent.instrumentation.servlet.v2_2.Servlet2HttpServerTracer",
-      "io.opentelemetry.javaagent.instrumentation.servlet.v2_2.ResponseWithStatus",
       "org.hypertrace.agent.filter.FilterProvider",
       "org.hypertrace.agent.filter.FilterEvaluator",
       "org.hypertrace.agent.filter.FilterResult",
@@ -148,7 +143,7 @@ public class Servlet2BodyInstrumentation extends Instrumenter.Default {
 
       HttpServletRequest httpRequest = (HttpServletRequest) request;
       HttpServletResponse httpResponse = (HttpServletResponse) response;
-      Span currentSpan = TRACER.getCurrentSpan();
+      Span currentSpan = InstrumentationName.TRACER.getCurrentSpan();
 
       rootStart = true;
       response = new BufferingHttpServletResponse(httpResponse);
@@ -191,7 +186,7 @@ public class Servlet2BodyInstrumentation extends Instrumenter.Default {
         }
 
         request.removeAttribute(ALREADY_LOADED);
-        Span currentSpan = TRACER.getCurrentSpan();
+        Span currentSpan = InstrumentationName.TRACER.getCurrentSpan();
 
         BufferingHttpServletResponse bufferingResponse = (BufferingHttpServletResponse) response;
         BufferingHttpServletRequest bufferingRequest = (BufferingHttpServletRequest) request;

--- a/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_0/InstrumentationName.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_0/InstrumentationName.java
@@ -16,10 +16,14 @@
 
 package io.opentelemetry.instrumentation.hypertrace.servlet.v3_0;
 
+import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.trace.Tracer;
+
 /**
  * A helper class to hold instrumentation name. The advice class cannot access the constant defined
  * in the instrumenter class.
  */
 public class InstrumentationName {
   public static final String[] INSTRUMENTATION_NAME = {"servlet", "servlet-3"};
+  public static final Tracer TRACER = OpenTelemetry.getTracer("org.hypertrace.agent.servlet");
 }

--- a/instrumentation/servlet/servlet-3.1/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_1/InstrumentationName.java
+++ b/instrumentation/servlet/servlet-3.1/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_1/InstrumentationName.java
@@ -16,10 +16,14 @@
 
 package io.opentelemetry.instrumentation.hypertrace.servlet.v3_1;
 
+import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.trace.Tracer;
+
 /**
  * A helper class to hold instrumentation name. The advice class cannot access the constant defined
  * in the instrumenter class.
  */
 public class InstrumentationName {
   public static final String[] INSTRUMENTATION_NAME = {"servlet", "servlet-3"};
+  public static final Tracer TRACER = OpenTelemetry.getTracer("org.hypertrace.agent.servlet");
 }

--- a/instrumentation/servlet/servlet-3.1/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_1/Servlet31Advice.java
+++ b/instrumentation/servlet/servlet-3.1/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_1/Servlet31Advice.java
@@ -16,8 +16,6 @@
 
 package io.opentelemetry.instrumentation.hypertrace.servlet.v3_1;
 
-import static io.opentelemetry.javaagent.instrumentation.servlet.v3_0.Servlet3HttpServerTracer.TRACER;
-
 import io.opentelemetry.instrumentation.hypertrace.servlet.common.ServletSpanDecorator;
 import io.opentelemetry.trace.Span;
 import java.util.Enumeration;
@@ -64,7 +62,7 @@ public class Servlet31Advice {
 
     HttpServletRequest httpRequest = (HttpServletRequest) request;
     HttpServletResponse httpResponse = (HttpServletResponse) response;
-    Span currentSpan = TRACER.getCurrentSpan();
+    Span currentSpan = InstrumentationName.TRACER.getCurrentSpan();
 
     rootStart = true;
     response = new BufferingHttpServletResponse(httpResponse);
@@ -106,7 +104,7 @@ public class Servlet31Advice {
       }
 
       request.removeAttribute(ALREADY_LOADED);
-      Span currentSpan = TRACER.getCurrentSpan();
+      Span currentSpan = InstrumentationName.TRACER.getCurrentSpan();
 
       AtomicBoolean responseHandled = new AtomicBoolean(false);
       if (request.isAsyncStarted()) {

--- a/instrumentation/servlet/servlet-3.1/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_1/Servlet31BodyInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.1/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_1/Servlet31BodyInstrumentation.java
@@ -66,11 +66,6 @@ public class Servlet31BodyInstrumentation extends Instrumenter.Default {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "io.opentelemetry.instrumentation.servlet.HttpServletRequestGetter",
-      "io.opentelemetry.instrumentation.servlet.ServletHttpServerTracer",
-      "io.opentelemetry.javaagent.instrumentation.servlet.v3_0.Servlet3HttpServerTracer",
-      // TODO Add these to bootstrap classloader so they don't have to referenced in every
-      // instrumentation, see https://github.com/hypertrace/javaagent/issues/17
       "org.hypertrace.agent.filter.FilterProvider",
       "org.hypertrace.agent.filter.FilterEvaluator",
       "org.hypertrace.agent.filter.FilterResult",

--- a/instrumentation/spark-web-framework-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/sparkjava/SparkJavaBodyInstrumentation.java
+++ b/instrumentation/spark-web-framework-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/sparkjava/SparkJavaBodyInstrumentation.java
@@ -81,7 +81,7 @@ public class SparkJavaBodyInstrumentation extends Instrumenter.Default {
       "io.opentelemetry.instrumentation.hypertrace.servlet.v3_1.BufferingHttpServletRequest",
       "io.opentelemetry.instrumentation.hypertrace.servlet.v3_1.BufferingHttpServletRequest$ServletInputStreamWrapper",
       "io.opentelemetry.instrumentation.hypertrace.servlet.v3_1.Servlet31Advice",
-      //        TODO Instrumentation name is not used in the advice method to check whether
+      // TODO Instrumentation name is not used in the advice method to check whether
       // instrumentation is enabled or not
       packageName + ".InstrumentationName",
     };


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

The classes are not needed since our instrumentations are not directly using them. Anyways they should be present in the app classloader since they are injected by OTEL. 

I also changing the typed tracer to the core API since we don't need the typed version - we are only getting the current span.