### PR TITLE
Print config when loaded

### DIFF
--- a/javaagent-core/build.gradle.kts
+++ b/javaagent-core/build.gradle.kts
@@ -23,6 +23,7 @@ idea {
 
 dependencies {
     api("io.opentelemetry:opentelemetry-api:0.10.0")
+    implementation("org.slf4j:slf4j-api:1.7.30")
 
     api("com.google.protobuf:protobuf-java:3.11.4")
     api("com.google.protobuf:protobuf-java-util:3.11.4")

--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/EnvironmentConfig.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/EnvironmentConfig.java
@@ -36,7 +36,7 @@ public class EnvironmentConfig {
   public static final String CONFIG_FILE_PROPERTY = HT_PREFIX + "config.file";
   static final String SERVICE_NAME = HT_PREFIX + "service.name";
 
-  static final String PROPAGATION_FORMATS = HT_PREFIX + "propagation_formats";
+  static final String PROPAGATION_FORMATS = HT_PREFIX + "propagation.formats";
 
   private static final String REPORTING_PREFIX = HT_PREFIX + "reporting.";
   static final String REPORTING_ADDRESS = REPORTING_PREFIX + "address";

--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/HypertraceConfig.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/HypertraceConfig.java
@@ -34,11 +34,15 @@ import org.hypertrace.agent.config.Config.Opa;
 import org.hypertrace.agent.config.Config.Opa.Builder;
 import org.hypertrace.agent.config.Config.PropagationFormat;
 import org.hypertrace.agent.config.Config.Reporting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** {@link HypertraceConfig} loads a yaml config from file. */
 public class HypertraceConfig {
 
   private HypertraceConfig() {}
+
+  private static final Logger log = LoggerFactory.getLogger(HypertraceConfig.class);
 
   private static AgentConfig agentConfig;
 
@@ -53,6 +57,9 @@ public class HypertraceConfig {
         if (agentConfig == null) {
           try {
             agentConfig = load();
+            log.info(
+                "Config loaded: {}",
+                JsonFormat.printer().omittingInsignificantWhitespace().print(agentConfig));
           } catch (IOException e) {
             throw new RuntimeException("Could not load config", e);
           }
@@ -79,6 +86,7 @@ public class HypertraceConfig {
   }
 
   /** Reset the config, use only in tests. */
+  @VisibleForTesting
   public static void reset() {
     agentConfig = null;
   }


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

The output is:

```json
[main] INFO io.opentelemetry.javaagent.shaded.org.hypertrace.agent.core.HypertraceConfig - Config loaded: {"serviceName":"unknown","reporting":{"address":"http://localhost:9411/api/v2/spans","opa":{"address":"http://opa.traceableai:8181/","pollPeriod":30}},"dataCapture":{"httpHeaders":{"request":true,"response":true},"httpBody":{"request":true,"response":true},"rpcMetadata":{"request":true,"response":true},"rpcBody":{"request":true,"response":true}},"propagationFormats":["TRACE_CONTEXT"]}
```

without stripping the whitespace it is, which is too large. For debug proposes the. ^^ is enough. It can be pasted into formatted for nicer outout.

```
[main] INFO io.opentelemetry.javaagent.shaded.org.hypertrace.agent.core.HypertraceConfig - Config loaded: {
  "serviceName": "unknown",
  "reporting": {
    "address": "http://localhost:9411/api/v2/spans",
    "opa": {
      "address": "http://opa.traceableai:8181/",
      "pollPeriod": 30
    }
  },
  "dataCapture": {
    "httpHeaders": {
      "request": true,
      "response": true
    },
    "httpBody": {
      "request": true,
      "response": true
    },
    "rpcMetadata": {
      "request": true,
      "response": true
    },
    "rpcBody": {
      "request": true,
      "response": true
    }
  },
  "propagationFormats": ["TRACE_CONTEXT"]
}
```