### PR TITLE
Add span processor that adds container ID to every span if Zipkin exporter is used

### DIFF
--- a/otel-extensions/build.gradle.kts
+++ b/otel-extensions/build.gradle.kts
@@ -3,8 +3,10 @@ plugins {
 }
 
 dependencies {
-    implementation("org.slf4j:slf4j-api:1.7.30")
     compileOnly("io.opentelemetry:opentelemetry-sdk:0.10.0")
+    implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.10.1")
+
+    implementation("org.slf4j:slf4j-api:1.7.30")
     implementation("com.google.auto.service:auto-service:1.0-rc7")
     annotationProcessor("com.google.auto.service:auto-service:1.0-rc7")
 

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/CgroupsReader.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/CgroupsReader.java
@@ -33,11 +33,11 @@ public class CgroupsReader {
 
   private final String cgroupsPath;
 
-  CgroupsReader() {
+  public CgroupsReader() {
     this.cgroupsPath = DEFAULT_CGROUPS_PATH;
   }
 
-  CgroupsReader(String cgroupsPath) {
+  public CgroupsReader(String cgroupsPath) {
     this.cgroupsPath = cgroupsPath;
   }
 

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/AddTagsSpanProcessor.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/AddTagsSpanProcessor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.otel.extensions.processor;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.resources.ResourceAttributes;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import org.hypertrace.agent.otel.extensions.CgroupsReader;
+
+public class AddTagsSpanProcessor implements SpanProcessor {
+
+  // initialize at startup because the processor is executed for every span.
+  private final String containerId;
+
+  public AddTagsSpanProcessor() {
+    CgroupsReader cgroupsReader = new CgroupsReader();
+    containerId = cgroupsReader.readContainerId();
+  }
+
+  @Override
+  public void onStart(Context parentContext, ReadWriteSpan span) {
+    span.setAttribute("foo", "bar");
+    if (containerId != null && !containerId.isEmpty()) {
+      span.setAttribute(ResourceAttributes.CONTAINER_ID, containerId);
+    }
+  }
+
+  @Override
+  public boolean isStartRequired() {
+    return true;
+  }
+
+  @Override
+  public void onEnd(ReadableSpan span) {}
+
+  @Override
+  public boolean isEndRequired() {
+    return false;
+  }
+
+  @Override
+  public CompletableResultCode shutdown() {
+    return CompletableResultCode.ofSuccess();
+  }
+
+  @Override
+  public CompletableResultCode forceFlush() {
+    return CompletableResultCode.ofSuccess();
+  }
+}

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/AddTagsSpanProcessor.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/AddTagsSpanProcessor.java
@@ -36,7 +36,6 @@ public class AddTagsSpanProcessor implements SpanProcessor {
 
   @Override
   public void onStart(Context parentContext, ReadWriteSpan span) {
-    span.setAttribute("foo", "bar");
     if (containerId != null && !containerId.isEmpty()) {
       span.setAttribute(ResourceAttributes.CONTAINER_ID, containerId);
     }

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/HypertraceTracerCustomizer.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/HypertraceTracerCustomizer.java
@@ -31,13 +31,11 @@ import io.opentelemetry.sdk.trace.TracerSdkManagement;
 @AutoService(TracerCustomizer.class)
 public class HypertraceTracerCustomizer implements TracerCustomizer {
 
-  public HypertraceTracerCustomizer() {
-    System.out.println("------>\n\n\n\n customizer");
-  }
-
   @Override
   public void configure(TracerSdkManagement tracerManagement) {
-    System.out.println("------>\n\n\n\n configuring SDK");
-    tracerManagement.addSpanProcessor(new AddTagsSpanProcessor());
+    String exporter = System.getProperty("otel.exporter");
+    if (exporter != null && exporter.contains("zipkin")) {
+      tracerManagement.addSpanProcessor(new AddTagsSpanProcessor());
+    }
   }
 }

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/HypertraceTracerCustomizer.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/HypertraceTracerCustomizer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.otel.extensions.processor;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.spi.TracerCustomizer;
+import io.opentelemetry.sdk.trace.TracerSdkManagement;
+
+/**
+ * This is a workaround to add container ID tags to spans when Zipkin exporter is used. Zipkin
+ * exporter does not add process attributes where the container ID is
+ * https://github.com/open-telemetry/opentelemetry-java/issues/1970.
+ *
+ * <p>Remove this once we migrate to OTEL exporter
+ * https://github.com/hypertrace/javaagent/issues/132
+ */
+@AutoService(TracerCustomizer.class)
+public class HypertraceTracerCustomizer implements TracerCustomizer {
+
+  public HypertraceTracerCustomizer() {
+    System.out.println("------>\n\n\n\n customizer");
+  }
+
+  @Override
+  public void configure(TracerSdkManagement tracerManagement) {
+    System.out.println("------>\n\n\n\n configuring SDK");
+    tracerManagement.addSpanProcessor(new AddTagsSpanProcessor());
+  }
+}

--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies{
     testImplementation("com.squareup.okhttp3:okhttp:4.9.0")
     testImplementation("org.awaitility:awaitility:4.0.3")
     testImplementation("io.opentelemetry:opentelemetry-proto:0.10.0")
+    testImplementation("io.opentelemetry:opentelemetry-sdk:0.10.0")
     testImplementation("com.google.protobuf:protobuf-java-util:3.13.0")
 }
 

--- a/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/SpringBootSmokeTest.java
@@ -17,6 +17,7 @@
 package org.hypertrace.agent.smoketest;
 
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.sdk.resources.ResourceAttributes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,7 +35,7 @@ import org.testcontainers.containers.GenericContainer;
 //    key = "SMOKETEST_JAVAAGENT_PATH",
 //    value =
 //
-// "/Users/ploffay/projects/hypertrace/javaagent/javaagent/build/libs/hypertrace-agent-0.3.2-all.jar")
+// "/Users/ploffay/projects/hypertrace/javaagent/javaagent/build/libs/hypertrace-agent-0.3.3-SNAPSHOT-all.jar")
 public class SpringBootSmokeTest extends AbstractSmokeTest {
 
   @Override
@@ -76,7 +77,11 @@ public class SpringBootSmokeTest extends AbstractSmokeTest {
 
     Assertions.assertEquals(1, traces.size());
     Assertions.assertEquals(
-        "service.name", traces.get(0).getResourceSpans(0).getResource().getAttributes(0).getKey());
+        ResourceAttributes.SERVICE_NAME.getKey(),
+        traces.get(0).getResourceSpans(0).getResource().getAttributes(0).getKey());
+    Assertions.assertEquals(
+        ResourceAttributes.CONTAINER_ID.getKey(),
+        traces.get(0).getResourceSpans(0).getResource().getAttributes(1).getKey());
     // value is specified in resources/ht-config.yaml
     Assertions.assertEquals(
         "app_under_test",
@@ -113,9 +118,6 @@ public class SpringBootSmokeTest extends AbstractSmokeTest {
                 .map(attribute -> attribute.getValue().getStringValue())
                 .count()
             > 0);
-    // TODO test the container ID once we switch from Zipkin exporter
-    // Zipkin exporter does not add resource attributes to span
-    // https://github.com/open-telemetry/opentelemetry-java/issues/1970
 
     // OTEL BS smoke test app does not have an endpoint that uses content type what we capture
     // enable once we add smoke tests apps to our build.


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

This is a workaround for https://github.com/open-telemetry/opentelemetry-java/issues/1970. 

It will be removed in  https://github.com/hypertrace/javaagent/issues/132