### PR TITLE
Remove java 8 bytecode bridge from helper classes

### DIFF
--- a/instrumentation/servlet/servlet-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v2_3/Servlet2BodyInstrumentationModule.java
+++ b/instrumentation/servlet/servlet-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v2_3/Servlet2BodyInstrumentationModule.java
@@ -83,7 +83,6 @@ public class Servlet2BodyInstrumentationModule extends InstrumentationModule {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge",
       "io.opentelemetry.instrumentation.hypertrace.servlet.common.ByteBufferData",
       "io.opentelemetry.instrumentation.hypertrace.servlet.common.CharBufferData",
       "io.opentelemetry.instrumentation.hypertrace.servlet.common.BufferedWriterWrapper",

--- a/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_0/Servlet30BodyInstrumentationModule.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_0/Servlet30BodyInstrumentationModule.java
@@ -77,7 +77,6 @@ public class Servlet30BodyInstrumentationModule extends InstrumentationModule {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge",
       "io.opentelemetry.instrumentation.hypertrace.servlet.common.ByteBufferData",
       "io.opentelemetry.instrumentation.hypertrace.servlet.common.CharBufferData",
       "io.opentelemetry.instrumentation.hypertrace.servlet.common.BufferedWriterWrapper",

--- a/instrumentation/servlet/servlet-3.1/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_1/Servlet31BodyInstrumentationModule.java
+++ b/instrumentation/servlet/servlet-3.1/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_1/Servlet31BodyInstrumentationModule.java
@@ -68,7 +68,6 @@ public class Servlet31BodyInstrumentationModule extends InstrumentationModule {
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge",
       "io.opentelemetry.instrumentation.hypertrace.servlet.common.ByteBufferData",
       "io.opentelemetry.instrumentation.hypertrace.servlet.common.CharBufferData",
       "io.opentelemetry.instrumentation.hypertrace.servlet.common.BufferedWriterWrapper",


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Not needed the class is present in the bootstrap classloader.