### PR TITLE
Ignore classes from other agents

### DIFF
--- a/otel-extensions/build.gradle.kts
+++ b/otel-extensions/build.gradle.kts
@@ -10,5 +10,6 @@ dependencies {
     implementation("com.google.auto.service:auto-service:1.0-rc7")
     annotationProcessor("com.google.auto.service:auto-service:1.0-rc7")
 
+    implementation("net.bytebuddy:byte-buddy:1.10.18")
     testImplementation("io.opentelemetry:opentelemetry-sdk:0.11.0")
 }

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/ByteBuddyIgnoreClassesCustomizer.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/ByteBuddyIgnoreClassesCustomizer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.otel.extensions;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.javaagent.spi.ByteBuddyAgentCustomizer;
+import java.security.ProtectionDomain;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.utility.JavaModule;
+
+@AutoService(ByteBuddyAgentCustomizer.class)
+public class ByteBuddyIgnoreClassesCustomizer implements ByteBuddyAgentCustomizer {
+
+  private static final String[] IGNORED_PACKAGES = {
+    "io.opentracing.contrib.specialagent.", "com.newrelic.", "com.nr.agent.", "datadog.",
+  };
+
+  @Override
+  public AgentBuilder customize(AgentBuilder agentBuilder) {
+    agentBuilder.ignore(
+        new AgentBuilder.RawMatcher() {
+          @Override
+          public boolean matches(
+              TypeDescription typeDescription,
+              ClassLoader classLoader,
+              JavaModule module,
+              Class<?> classBeingRedefined,
+              ProtectionDomain protectionDomain) {
+
+            if (classLoader == null) {}
+            String className =
+                classLoader == null
+                    ? typeDescription.getTypeName()
+                    : classLoader.getClass().getName();
+            return matchesIgnoredClassName(IGNORED_PACKAGES, className);
+          }
+        });
+
+    return null;
+  }
+
+  private static boolean matchesIgnoredClassName(String[] ignoredClasses, String className) {
+    for (String ignoredClass : ignoredClasses) {
+      if (className.startsWith(ignoredClass)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/ByteBuddyIgnoreClassesCustomizer.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/ByteBuddyIgnoreClassesCustomizer.java
@@ -32,7 +32,7 @@ public class ByteBuddyIgnoreClassesCustomizer implements ByteBuddyAgentCustomize
 
   @Override
   public AgentBuilder customize(AgentBuilder agentBuilder) {
-    agentBuilder.ignore(
+    return agentBuilder.ignore(
         new AgentBuilder.RawMatcher() {
           @Override
           public boolean matches(
@@ -50,8 +50,6 @@ public class ByteBuddyIgnoreClassesCustomizer implements ByteBuddyAgentCustomize
             return matchesIgnoredClassName(IGNORED_PACKAGES, className);
           }
         });
-
-    return null;
   }
 
   private static boolean matchesIgnoredClassName(String[] ignoredClasses, String className) {

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/ByteBuddyIgnoreClassesCustomizer.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/ByteBuddyIgnoreClassesCustomizer.java
@@ -42,7 +42,6 @@ public class ByteBuddyIgnoreClassesCustomizer implements ByteBuddyAgentCustomize
               Class<?> classBeingRedefined,
               ProtectionDomain protectionDomain) {
 
-            if (classLoader == null) {}
             String className =
                 classLoader == null
                     ? typeDescription.getTypeName()
@@ -53,6 +52,10 @@ public class ByteBuddyIgnoreClassesCustomizer implements ByteBuddyAgentCustomize
   }
 
   private static boolean matchesIgnoredClassName(String[] ignoredClasses, String className) {
+    if (className == null) {
+      return false;
+    }
+
     for (String ignoredClass : ignoredClasses) {
       if (className.startsWith(ignoredClass)) {
         return true;

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/ByteBuddyIgnoreClassesCustomizer.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/ByteBuddyIgnoreClassesCustomizer.java
@@ -42,11 +42,13 @@ public class ByteBuddyIgnoreClassesCustomizer implements ByteBuddyAgentCustomize
               Class<?> classBeingRedefined,
               ProtectionDomain protectionDomain) {
 
-            String className =
-                classLoader == null
-                    ? typeDescription.getTypeName()
-                    : classLoader.getClass().getName();
-            return matchesIgnoredClassName(IGNORED_PACKAGES, className);
+            if (classLoader == null) {
+              String className = typeDescription.getTypeName();
+              return matchesIgnoredClassName(IGNORED_PACKAGES, className);
+            }
+
+            String classLoaderName = classLoader.getClass().getName();
+            return matchesIgnoredClassName(IGNORED_PACKAGES, classLoaderName);
           }
         });
   }


### PR DESCRIPTION
Related to #65 

Other agents classes are already excluded in OTEL upstream. The https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1812 and https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/1813 adds exclusion for datadog and newrelic to the upstream. Our fix might be needed since some classes used by datadog are not shaded and live in agent's classloader (e.g. okhttp exporter).

Signed-off-by: Pavol Loffay <p.loffay@gmail.com>