### PR TITLE
Remove gradle exclusion

### DIFF
--- a/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/apachehttpclient/v4_0/OutputStreamInstrumentationModule.java
+++ b/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/apachehttpclient/v4_0/OutputStreamInstrumentationModule.java
@@ -20,9 +20,7 @@ import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementM
 import static io.opentelemetry.javaagent.tooling.matcher.NameMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.is;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
-import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 

--- a/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/apachehttpclient/v4_0/OutputStreamInstrumentationModule.java
+++ b/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/apachehttpclient/v4_0/OutputStreamInstrumentationModule.java
@@ -66,10 +66,7 @@ public class OutputStreamInstrumentationModule extends InstrumentationModule {
 
     @Override
     public ElementMatcher<? super TypeDescription> typeMatcher() {
-      // TODO exclude gradle classes in AgentBuilder SPI in AbstractTest
-      // The gradle classes are excluded only for test purposes
-      return extendsClass(named("java.io.OutputStream"))
-          .and(not(nameStartsWith("org.gradle.internal")));
+      return extendsClass(named("java.io.OutputStream"));
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

It does not seem to be needed after bump to OTEL 0.11.0