### PR TITLE
Remove order from JAX-RS instrumentation

### DIFF
--- a/instrumentation/jaxrs-client-2.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/jaxrs/v2_0/JaxrsClientBodyInstrumentationModule.java
+++ b/instrumentation/jaxrs-client-2.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/jaxrs/v2_0/JaxrsClientBodyInstrumentationModule.java
@@ -39,11 +39,6 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(InstrumentationModule.class)
 public class JaxrsClientBodyInstrumentationModule extends InstrumentationModule {
 
-  @Override
-  public int getOrder() {
-    return 1;
-  }
-
   public JaxrsClientBodyInstrumentationModule() {
     super(JaxrsClientBodyInstrumentationName.PRIMARY, JaxrsClientBodyInstrumentationName.OTHER);
   }


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Not needed as the order of filter is specified in the client builder when adding the filter.