### PR TITLE
Optimize advice method loading

### DIFF
--- a/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/apachehttpclient/v4_0/ApacheClientInstrumentationModule.java
+++ b/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/apachehttpclient/v4_0/ApacheClientInstrumentationModule.java
@@ -90,7 +90,7 @@ public class ApacheClientInstrumentationModule extends InstrumentationModule {
       // instrument response
       transformers.put(
           isMethod().and(named("execute")).and(not(isAbstract())),
-          HttpClient_ExecuteAdvice_response.class.getName());
+          ApacheClientInstrumentationModule.class.getName() + "$HttpClient_ExecuteAdvice_response");
 
       // instrument request
       transformers.put(
@@ -98,13 +98,13 @@ public class ApacheClientInstrumentationModule extends InstrumentationModule {
               .and(named("execute"))
               .and(not(isAbstract()))
               .and(takesArgument(0, hasSuperType(named("org.apache.http.HttpMessage")))),
-          HttpClient_ExecuteAdvice_request0.class.getName());
+          ApacheClientInstrumentationModule.class.getName() + "$HttpClient_ExecuteAdvice_request0");
       transformers.put(
           isMethod()
               .and(named("execute"))
               .and(not(isAbstract()))
               .and(takesArgument(1, hasSuperType(named("org.apache.http.HttpMessage")))),
-          HttpClient_ExecuteAdvice_request1.class.getName());
+          ApacheClientInstrumentationModule.class.getName() + "$HttpClient_ExecuteAdvice_request1");
 
       return transformers;
     }
@@ -197,12 +197,12 @@ public class ApacheClientInstrumentationModule extends InstrumentationModule {
       // instrumentation for request body along with OutputStream instrumentation
       transformers.put(
           named("writeTo").and(takesArguments(1)).and(takesArgument(0, is(OutputStream.class))),
-          HttpEntity_WriteToAdvice.class.getName());
+          ApacheClientInstrumentationModule.class.getName() + "$HttpEntity_WriteToAdvice");
 
       // instrumentation for response body along with InputStream instrumentation
       transformers.put(
           named("getContent").and(takesArguments(0)).and(returns(InputStream.class)),
-          HttpEntity_GetContentAdvice.class.getName());
+          ApacheClientInstrumentationModule.class.getName() + "$HttpEntity_GetContentAdvice");
       return transformers;
     }
   }

--- a/instrumentation/java-streams/src/main/java/io/opentelemetry/instrumentation/hypertrace/java/inputstream/InputStreamInstrumentationModule.java
+++ b/instrumentation/java-streams/src/main/java/io/opentelemetry/instrumentation/hypertrace/java/inputstream/InputStreamInstrumentationModule.java
@@ -75,13 +75,13 @@ public class InputStreamInstrumentationModule extends InstrumentationModule {
       Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
       transformers.put(
           namedOneOf("read").and(takesArguments(0)).and(isPublic()),
-          InputStream_ReadNoArgsAdvice.class.getName());
+          InputStreamInstrumentationModule.class.getName() + "$InputStream_ReadNoArgsAdvice");
       transformers.put(
           namedOneOf("read")
               .and(takesArguments(1))
               .and(takesArgument(0, is(byte[].class)))
               .and(isPublic()),
-          InputStream_ReadByteArrayAdvice.class.getName());
+          InputStreamInstrumentationModule.class.getName() + "$InputStream_ReadByteArrayAdvice");
       transformers.put(
           namedOneOf("read")
               .and(takesArguments(3))
@@ -89,7 +89,8 @@ public class InputStreamInstrumentationModule extends InstrumentationModule {
               .and(takesArgument(1, is(int.class)))
               .and(takesArgument(2, is(int.class)))
               .and(isPublic()),
-          InputStream_ReadByteArrayOffsetAdvice.class.getName());
+          InputStreamInstrumentationModule.class.getName()
+              + "$InputStream_ReadByteArrayOffsetAdvice");
       transformers.put(
           namedOneOf("readAllBytes").and(takesArguments(0)).and(isPublic()),
           InputStream_ReadAllBytes.class.getName());
@@ -100,7 +101,7 @@ public class InputStreamInstrumentationModule extends InstrumentationModule {
               .and(takesArgument(1, is(int.class)))
               .and(takesArgument(2, is(int.class)))
               .and(isPublic()),
-          InputStream_ReadNBytes.class.getName());
+          InputStreamInstrumentationModule.class.getName() + "$InputStream_ReadNBytes");
       return transformers;
     }
   }

--- a/instrumentation/java-streams/src/main/java/io/opentelemetry/instrumentation/hypertrace/java/outputstream/OutputStreamInstrumentationModule.java
+++ b/instrumentation/java-streams/src/main/java/io/opentelemetry/instrumentation/hypertrace/java/outputstream/OutputStreamInstrumentationModule.java
@@ -75,13 +75,13 @@ public class OutputStreamInstrumentationModule extends InstrumentationModule {
               .and(takesArguments(1))
               .and(takesArgument(0, is(int.class)))
               .and(isPublic()),
-          OutputStream_WriteIntAdvice.class.getName());
+          OutputStreamInstrumentationModule.class.getName() + "$OutputStream_WriteIntAdvice");
       transformers.put(
           namedOneOf("write")
               .and(takesArguments(1))
               .and(takesArgument(0, is(byte[].class)))
               .and(isPublic()),
-          OutputStream_WriteByteArrAdvice.class.getName());
+          OutputStreamInstrumentationModule.class.getName() + "$OutputStream_WriteByteArrAdvice");
       transformers.put(
           namedOneOf("write")
               .and(takesArguments(3))
@@ -89,7 +89,8 @@ public class OutputStreamInstrumentationModule extends InstrumentationModule {
               .and(takesArgument(1, is(int.class)))
               .and(takesArgument(2, is(int.class)))
               .and(isPublic()),
-          OutputStream_WriteByteArrOffsetAdvice.class.getName());
+          OutputStreamInstrumentationModule.class.getName()
+              + "$OutputStream_WriteByteArrOffsetAdvice");
       return transformers;
     }
   }

--- a/instrumentation/jaxrs-client-2.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/jaxrs/v2_0/JaxrsClientBodyInstrumentationModule.java
+++ b/instrumentation/jaxrs-client-2.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/jaxrs/v2_0/JaxrsClientBodyInstrumentationModule.java
@@ -64,7 +64,7 @@ public class JaxrsClientBodyInstrumentationModule extends InstrumentationModule 
     public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
       return singletonMap(
           named("build").and(returns(hasInterface(named("javax.ws.rs.client.Client")))),
-          ClientBuilder_build_Advice.class.getName());
+          JaxrsClientBodyInstrumentationModule.class.getName() + "$ClientBuilder_build_Advice");
     }
   }
 

--- a/instrumentation/servlet/servlet-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v2_3/Servlet2BodyInstrumentationModule.java
+++ b/instrumentation/servlet/servlet-2.3/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v2_3/Servlet2BodyInstrumentationModule.java
@@ -98,7 +98,7 @@ public class Servlet2BodyInstrumentationModule extends InstrumentationModule {
               .and(takesArgument(0, named("javax.servlet.ServletRequest")))
               .and(takesArgument(1, named("javax.servlet.ServletResponse")))
               .and(isPublic()),
-          Filter2Advice.class.getName());
+          Servlet2BodyInstrumentationModule.class.getName() + "$Filter2Advice");
     }
   }
 

--- a/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_0/Servlet30BodyInstrumentationModule.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/instrumentation/hypertrace/servlet/v3_0/Servlet30BodyInstrumentationModule.java
@@ -93,14 +93,13 @@ public class Servlet30BodyInstrumentationModule extends InstrumentationModule {
               .and(takesArgument(0, named("javax.servlet.ServletRequest")))
               .and(takesArgument(1, named("javax.servlet.ServletResponse")))
               .and(isPublic()),
-          FilterAdvice.class.getName());
+          Servlet30BodyInstrumentationModule.class.getName() + "$FilterAdvice");
     }
   }
 
   public static class FilterAdvice {
     // request attribute key injected at first filerChain.doFilter
     private static final String ALREADY_LOADED = "__org.hypertrace.agent.on_start_executed";
-    private static final String TRACER_NAME = "org.hypertrace.agent.servlet";
 
     @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
     public static boolean start(


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Using string name for the advice class assures that advice class is not loaded by JVM just by ByteBuddy. 