### PR TITLE
Use bounded size buffers

### DIFF
--- a/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/apachehttpclient/v4_0/ApacheClientInstrumentationModule.java
+++ b/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/apachehttpclient/v4_0/ApacheClientInstrumentationModule.java
@@ -51,6 +51,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpMessage;
 import org.apache.http.HttpResponse;
 import org.hypertrace.agent.config.Config.AgentConfig;
+import org.hypertrace.agent.core.BoundedByteArrayOutputStreamFactory;
 import org.hypertrace.agent.core.ContentEncodingUtils;
 import org.hypertrace.agent.core.ContentLengthUtils;
 import org.hypertrace.agent.core.ContentTypeUtils;
@@ -238,7 +239,7 @@ public class ApacheClientInstrumentationModule extends InstrumentationModule {
       SpanAndBuffer spanAndBuffer =
           new SpanAndBuffer(
               clientSpan,
-              new ByteArrayOutputStream((int) contentSize),
+              BoundedByteArrayOutputStreamFactory.create((int) contentSize),
               HypertraceSemanticAttributes.HTTP_RESPONSE_BODY,
               charset);
       GlobalObjectRegistry.inputStreamToSpanAndBufferMap.put(inputStream, spanAndBuffer);
@@ -257,7 +258,8 @@ public class ApacheClientInstrumentationModule extends InstrumentationModule {
       if (contentSize <= 0 || contentSize == Long.MAX_VALUE) {
         contentSize = ContentLengthUtils.DEFAULT;
       }
-      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream((int) contentSize);
+      ByteArrayOutputStream byteArrayOutputStream =
+          BoundedByteArrayOutputStreamFactory.create((int) contentSize);
 
       GlobalObjectRegistry.outputStreamToBufferMap.put(outputStream, byteArrayOutputStream);
     }

--- a/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/apachehttpclient/v4_0/ApacheHttpClientUtils.java
+++ b/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/apachehttpclient/v4_0/ApacheHttpClientUtils.java
@@ -29,6 +29,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpMessage;
 import org.hypertrace.agent.config.Config.AgentConfig;
+import org.hypertrace.agent.core.BoundedByteArrayOutputStreamFactory;
 import org.hypertrace.agent.core.ContentEncodingUtils;
 import org.hypertrace.agent.core.HypertraceConfig;
 import org.hypertrace.agent.core.HypertraceSemanticAttributes;
@@ -81,7 +82,7 @@ public class ApacheHttpClientUtils {
 
     if (entity.isRepeatable()) {
       try {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        ByteArrayOutputStream byteArrayOutputStream = BoundedByteArrayOutputStreamFactory.create();
         entity.writeTo(byteArrayOutputStream);
         String encoding =
             entity.getContentEncoding() != null ? entity.getContentEncoding().getValue() : "";

--- a/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/apachehttpclient/v4_0/readall/ApacheClientReadAllInstrumentationModule.java
+++ b/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/apachehttpclient/v4_0/readall/ApacheClientReadAllInstrumentationModule.java
@@ -48,6 +48,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
+import org.hypertrace.agent.core.BoundedByteArrayOutputStreamFactory;
 import org.hypertrace.agent.core.ContentTypeUtils;
 import org.hypertrace.agent.core.GlobalObjectRegistry;
 import org.hypertrace.agent.core.HypertraceSemanticAttributes;
@@ -195,7 +196,8 @@ public class ApacheClientReadAllInstrumentationModule extends InstrumentationMod
           }
 
           BufferedInputStream bufferedInputStream = new BufferedInputStream(inputStream);
-          ByteArrayOutputStream buffer = new ByteArrayOutputStream((int) contentSize);
+          ByteArrayOutputStream buffer =
+              BoundedByteArrayOutputStreamFactory.create((int) contentSize);
           byte ch;
           while ((ch = (byte) bufferedInputStream.read()) != -1) {
             buffer.write(ch);

--- a/instrumentation/jaxrs-client-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/jaxrs/v2_0/JaxrsClientEntityInterceptor.java
+++ b/instrumentation/jaxrs-client-2.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/jaxrs/v2_0/JaxrsClientEntityInterceptor.java
@@ -31,6 +31,7 @@ import javax.ws.rs.ext.ReaderInterceptorContext;
 import javax.ws.rs.ext.WriterInterceptor;
 import javax.ws.rs.ext.WriterInterceptorContext;
 import org.hypertrace.agent.config.Config.AgentConfig;
+import org.hypertrace.agent.core.BoundedByteArrayOutputStreamFactory;
 import org.hypertrace.agent.core.ContentEncodingUtils;
 import org.hypertrace.agent.core.ContentLengthUtils;
 import org.hypertrace.agent.core.ContentTypeUtils;
@@ -78,7 +79,7 @@ public class JaxrsClientEntityInterceptor implements ReaderInterceptor, WriterIn
       String contentLengthStr = responseContext.getHeaders().getFirst(HttpHeaders.CONTENT_LENGTH);
       int contentLength = ContentLengthUtils.parseLength(contentLengthStr);
 
-      ByteArrayOutputStream buffer = new ByteArrayOutputStream(contentLength);
+      ByteArrayOutputStream buffer = BoundedByteArrayOutputStreamFactory.create(contentLength);
       GlobalObjectRegistry.inputStreamToSpanAndBufferMap.put(
           entityStream,
           new SpanAndBuffer(
@@ -118,7 +119,7 @@ public class JaxrsClientEntityInterceptor implements ReaderInterceptor, WriterIn
     }
 
     // TODO length is not known
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    ByteArrayOutputStream buffer = BoundedByteArrayOutputStreamFactory.create();
     OutputStream entityStream = requestContext.getOutputStream();
     try {
       GlobalObjectRegistry.outputStreamToBufferMap.put(entityStream, buffer);

--- a/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/common/ByteBufferData.java
+++ b/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/common/ByteBufferData.java
@@ -19,11 +19,13 @@ package io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.common;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import org.hypertrace.agent.core.HypertraceConfig;
 
 public class ByteBufferData {
 
   private static final int MIN_BUFFER_SIZE = 128;
-  private static final int MAX_BUFFER_SIZE = 1048576; // 1MB
+  private static final int MAX_BUFFER_SIZE =
+      HypertraceConfig.get().getDataCapture().getBodyMaxSizeBytes().getValue();
   private static final int GROW_FACTOR = 4;
   private static final Charset ISO_8859_1 = StandardCharsets.ISO_8859_1;
   private Charset charset;

--- a/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/common/CharBufferData.java
+++ b/instrumentation/servlet/servlet-common/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/common/CharBufferData.java
@@ -17,11 +17,13 @@
 package io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.common;
 
 import java.util.Arrays;
+import org.hypertrace.agent.core.HypertraceConfig;
 
 public class CharBufferData {
 
   private static final int MIN_BUFFER_SIZE = 128;
-  private static final int MAX_BUFFER_SIZE = 1048576; // 1MB
+  private static final int MAX_BUFFER_SIZE =
+      HypertraceConfig.get().getDataCapture().getBodyMaxSizeBytes().getValue();
   private static final int GROW_FACTOR = 4;
   private char[] buffer;
   private int bufferLen;

--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/BoundedByteArrayOutputStream.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/BoundedByteArrayOutputStream.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.core;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+/**
+ * {@link ByteArrayOutputStream} with a bounded capacity. Write methods are no-op if the size
+ * reaches the maximum capacity.
+ */
+public class BoundedByteArrayOutputStream extends ByteArrayOutputStream {
+
+  private final int maxCapacity;
+
+  BoundedByteArrayOutputStream(int maxCapacity) {
+    this.maxCapacity = maxCapacity;
+  }
+
+  BoundedByteArrayOutputStream(int maxCapacity, int size) {
+    super(size);
+    this.maxCapacity = maxCapacity;
+  }
+
+  @Override
+  public synchronized void write(int b) {
+    if (size() == maxCapacity) {
+      return;
+    }
+    super.write(b);
+  }
+
+  @Override
+  public void write(byte[] b) throws IOException {
+    // ByteArrayOutputStream calls write(b, off, len)
+    super.write(b);
+  }
+
+  @Override
+  public synchronized void write(byte[] b, int off, int len) {
+    int size = size();
+    if (size + len > maxCapacity) {
+      super.write(b, off, maxCapacity - size);
+      return;
+    }
+    super.write(b, off, len);
+  }
+}

--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/BoundedByteArrayOutputStreamFactory.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/BoundedByteArrayOutputStreamFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.core;
+
+public class BoundedByteArrayOutputStreamFactory {
+
+  private static final int DEFAULT_SIZE = 128;
+
+  public static BoundedByteArrayOutputStream create() {
+    return new BoundedByteArrayOutputStream(DEFAULT_SIZE);
+  }
+
+  public static BoundedByteArrayOutputStream create(int initialSize) {
+    if (initialSize > DEFAULT_SIZE) {
+      initialSize = DEFAULT_SIZE;
+    }
+    return new BoundedByteArrayOutputStream(DEFAULT_SIZE, initialSize);
+  }
+}

--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/EnvironmentConfig.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/EnvironmentConfig.java
@@ -47,6 +47,7 @@ public class EnvironmentConfig {
   static final String OPA_POLL_PERIOD = OPA_PREFIX + "poll.period.seconds";
 
   private static final String CAPTURE_PREFIX = HT_PREFIX + "data.capture.";
+  public static final String CAPTURE_BODY_MAX_SIZE_BYTES = CAPTURE_PREFIX + "body.max.size.bytes";
   public static final String CAPTURE_HTTP_HEADERS_PREFIX = CAPTURE_PREFIX + "http.headers.";
   public static final String CAPTURE_HTTP_BODY_PREFIX = CAPTURE_PREFIX + "http.body.";
   public static final String CAPTURE_RPC_METADATA_PREFIX = CAPTURE_PREFIX + "rpc.metadata.";
@@ -106,6 +107,11 @@ public class EnvironmentConfig {
   }
 
   private static DataCapture.Builder setDefaultsToDataCapture(DataCapture.Builder builder) {
+    String bodyMaxSizeBytes = getProperty(CAPTURE_BODY_MAX_SIZE_BYTES);
+    if (bodyMaxSizeBytes != null) {
+      builder.setBodyMaxSizeBytes(
+          Int32Value.newBuilder().setValue(Integer.valueOf(bodyMaxSizeBytes)).build());
+    }
     builder.setHttpHeaders(
         applyMessageDefaults(builder.getHttpHeaders().toBuilder(), CAPTURE_HTTP_HEADERS_PREFIX));
     builder.setHttpBody(

--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/HypertraceConfig.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/HypertraceConfig.java
@@ -57,6 +57,8 @@ public class HypertraceConfig {
   static final String DEFAULT_REPORTING_ENDPOINT = "http://localhost:9411/api/v2/spans";
   static final String DEFAULT_OPA_ENDPOINT = "http://opa.traceableai:8181/";
   static final int DEFAULT_OPA_POLL_PERIOD_SECONDS = 30;
+  // 128 KiB
+  static final int DEFAULT_BODY_MAX_SIZE_BYTES = 128 * 1024;
 
   public static AgentConfig get() {
     if (agentConfig == null) {
@@ -199,6 +201,10 @@ public class HypertraceConfig {
     builder.setHttpBody(applyMessageDefaults(builder.getHttpBody().toBuilder()));
     builder.setRpcMetadata(applyMessageDefaults(builder.getRpcMetadata().toBuilder()));
     builder.setRpcBody(applyMessageDefaults(builder.getRpcBody().toBuilder()));
+    if (!builder.hasBodyMaxSizeBytes()) {
+      builder.setBodyMaxSizeBytes(
+          Int32Value.newBuilder().setValue(DEFAULT_BODY_MAX_SIZE_BYTES).build());
+    }
     return builder;
   }
 

--- a/javaagent-core/src/test/java/org/hypertrace/agent/core/BoundedByteArrayOutputStreamTest.java
+++ b/javaagent-core/src/test/java/org/hypertrace/agent/core/BoundedByteArrayOutputStreamTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.core;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BoundedByteArrayOutputStreamTest {
+
+  private static final String ONE_TO_TEN = "0123456789";
+
+  @Test
+  public void writeArrTheSameSizeAsBuffer() throws IOException {
+    BoundedByteArrayOutputStream boundedBuffer = new BoundedByteArrayOutputStream(10);
+
+    boundedBuffer.write(ONE_TO_TEN.getBytes());
+    Assertions.assertEquals(10, boundedBuffer.size());
+    boundedBuffer.write("01234".getBytes());
+    Assertions.assertEquals(10, boundedBuffer.size());
+    Assertions.assertEquals(ONE_TO_TEN, boundedBuffer.toString());
+  }
+
+  @Test
+  public void writeArrSmallerSizeAsBuffer() throws IOException {
+    BoundedByteArrayOutputStream boundedBuffer = new BoundedByteArrayOutputStream(15);
+
+    boundedBuffer.write(ONE_TO_TEN.getBytes());
+    Assertions.assertEquals(10, boundedBuffer.size());
+    boundedBuffer.write("0123456".getBytes());
+    Assertions.assertEquals(15, boundedBuffer.size());
+    Assertions.assertEquals(ONE_TO_TEN + "01234", boundedBuffer.toString());
+  }
+
+  @Test
+  public void writeByteSmallerSizeAsBuffer() throws IOException {
+    BoundedByteArrayOutputStream boundedBuffer = new BoundedByteArrayOutputStream(5);
+
+    boundedBuffer.write('0');
+    boundedBuffer.write('1');
+    boundedBuffer.write('2');
+    boundedBuffer.write('3');
+    boundedBuffer.write('4');
+    Assertions.assertEquals(5, boundedBuffer.size());
+    boundedBuffer.write('5');
+    Assertions.assertEquals(5, boundedBuffer.size());
+    boundedBuffer.write("01234".getBytes());
+    Assertions.assertEquals(5, boundedBuffer.size());
+    Assertions.assertEquals("01234", boundedBuffer.toString());
+  }
+}

--- a/javaagent-core/src/test/java/org/hypertrace/agent/core/EnvironmentConfigTest.java
+++ b/javaagent-core/src/test/java/org/hypertrace/agent/core/EnvironmentConfigTest.java
@@ -33,6 +33,7 @@ class EnvironmentConfigTest {
   @ClearSystemProperty(key = EnvironmentConfig.OPA_POLL_PERIOD)
   @ClearSystemProperty(key = EnvironmentConfig.PROPAGATION_FORMATS)
   @ClearSystemProperty(key = EnvironmentConfig.CAPTURE_HTTP_BODY_PREFIX + "request")
+  @ClearSystemProperty(key = EnvironmentConfig.CAPTURE_BODY_MAX_SIZE_BYTES)
   public void systemProperties() {
     // when tests are run in parallel the env vars/sys props set it junit-pioneer are visible to
     // parallel tests
@@ -42,6 +43,7 @@ class EnvironmentConfigTest {
     System.setProperty(EnvironmentConfig.OPA_ENDPOINT, "http://azkaban:9090");
     System.setProperty(EnvironmentConfig.OPA_POLL_PERIOD, "10");
     System.setProperty(EnvironmentConfig.PROPAGATION_FORMATS, "B3,TRACECONTEXT");
+    System.setProperty(EnvironmentConfig.CAPTURE_BODY_MAX_SIZE_BYTES, "512");
 
     AgentConfig.Builder configBuilder = AgentConfig.newBuilder();
     configBuilder.setServiceName(StringValue.newBuilder().setValue("foo"));
@@ -56,6 +58,7 @@ class EnvironmentConfigTest {
         "http://azkaban:9090", agentConfig.getReporting().getOpa().getEndpoint().getValue());
     Assertions.assertEquals(
         10, agentConfig.getReporting().getOpa().getPollPeriodSeconds().getValue());
+    Assertions.assertEquals(512, agentConfig.getDataCapture().getBodyMaxSizeBytes().getValue());
     Assertions.assertEquals(true, agentConfig.getReporting().getSecure().getValue());
     Assertions.assertEquals(
         true, agentConfig.getDataCapture().getHttpBody().getRequest().getValue());

--- a/javaagent-core/src/test/java/org/hypertrace/agent/core/HypertraceConfigTest.java
+++ b/javaagent-core/src/test/java/org/hypertrace/agent/core/HypertraceConfigTest.java
@@ -49,6 +49,9 @@ public class HypertraceConfigTest {
         HypertraceConfig.DEFAULT_OPA_POLL_PERIOD_SECONDS,
         agentConfig.getReporting().getOpa().getPollPeriodSeconds().getValue());
     Assertions.assertEquals(
+        HypertraceConfig.DEFAULT_BODY_MAX_SIZE_BYTES,
+        agentConfig.getDataCapture().getBodyMaxSizeBytes().getValue());
+    Assertions.assertEquals(
         true, agentConfig.getDataCapture().getHttpHeaders().getRequest().getValue());
     Assertions.assertEquals(
         true, agentConfig.getDataCapture().getHttpHeaders().getResponse().getValue());
@@ -99,6 +102,7 @@ public class HypertraceConfigTest {
         "http://opa.localhost:8181/", agentConfig.getReporting().getOpa().getEndpoint().getValue());
     Assertions.assertEquals(
         12, agentConfig.getReporting().getOpa().getPollPeriodSeconds().getValue());
+    Assertions.assertEquals(16, agentConfig.getDataCapture().getBodyMaxSizeBytes().getValue());
     Assertions.assertEquals(
         true, agentConfig.getDataCapture().getHttpHeaders().getRequest().getValue());
     Assertions.assertEquals(

--- a/javaagent-core/src/test/resources/config.yaml
+++ b/javaagent-core/src/test/resources/config.yaml
@@ -8,6 +8,7 @@ reporting:
     endpoint: http://opa.localhost:8181/
     pollPeriodSeconds: 12
 dataCapture:
+  bodyMaxSizeBytes: 16
   httpHeaders:
     request: true
     response: false


### PR DESCRIPTION
Resolves to #165 


Depends on https://github.com/hypertrace/agent-config/pull/39

TODO

- [x] set also https://github.com/open-telemetry/opentelemetry-java/blob/91dc1191813a887caba594d483fe8718ce79d7fc/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java#L32 -- the defaults look sane - unlimited attribute length and high number of attributes allowed https://github.com/open-telemetry/opentelemetry-java/blob/master/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfigBuilder.java#L33 

Signed-off-by: Pavol Loffay <p.loffay@gmail.com>