### PR TITLE
Use name HT in stream instrumentation

### DIFF
--- a/instrumentation/java-streams/src/main/java/io/opentelemetry/instrumentation/hypertrace/java/inputstream/InputStreamInstrumentationModule.java
+++ b/instrumentation/java-streams/src/main/java/io/opentelemetry/instrumentation/hypertrace/java/inputstream/InputStreamInstrumentationModule.java
@@ -55,7 +55,7 @@ import org.hypertrace.agent.core.GlobalObjectRegistry;
 public class InputStreamInstrumentationModule extends InstrumentationModule {
 
   public InputStreamInstrumentationModule() {
-    super("inputstream");
+    super("inputstream", "ht");
   }
 
   @Override

--- a/instrumentation/java-streams/src/main/java/io/opentelemetry/instrumentation/hypertrace/java/outputstream/OutputStreamInstrumentationModule.java
+++ b/instrumentation/java-streams/src/main/java/io/opentelemetry/instrumentation/hypertrace/java/outputstream/OutputStreamInstrumentationModule.java
@@ -52,7 +52,7 @@ import org.hypertrace.agent.core.GlobalObjectRegistry;
 public class OutputStreamInstrumentationModule extends InstrumentationModule {
 
   public OutputStreamInstrumentationModule() {
-    super("outputstream");
+    super("outputstream", "ht");
   }
 
   @Override


### PR DESCRIPTION
This allows us to disable all HT instrumentation with a single name.


Signed-off-by: Pavol Loffay <p.loffay@gmail.com>