### PR TITLE
Remove webflux exclusion from netty 4.0

### DIFF
--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/NettyChannelPipelineInstrumentation.java
@@ -21,7 +21,6 @@ import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.AgentElementM
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import io.netty.channel.ChannelHandler;
@@ -46,8 +45,7 @@ public class NettyChannelPipelineInstrumentation implements TypeInstrumentation 
 
   @Override
   public ElementMatcher<ClassLoader> classLoaderOptimization() {
-    return hasClassesNamed("io.netty.channel.ChannelPipeline")
-        .and(not(hasClassesNamed("org.springframework.web.reactive.HandlerAdapter")));
+    return hasClassesNamed("io.netty.channel.ChannelPipeline");
   }
 
   @Override


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Not needed, webflux is supported now and it is not using netty 4.0 anyways.