### PR TITLE
Ignore appdynamics classloaders

### DIFF
--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceGlobalIgnoreMatcher.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceGlobalIgnoreMatcher.java
@@ -39,7 +39,7 @@ public class HypertraceGlobalIgnoreMatcher implements IgnoreMatcherProvider {
   @Override
   public Result classloader(ClassLoader classLoader) {
     String name = classLoader.getClass().getName();
-    if (name.startsWith("com.singularity.*")) {
+    if (name.startsWith("com.singularity.")) {
       return Result.IGNORE;
     }
     return Result.DEFAULT;

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceGlobalIgnoreMatcher.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceGlobalIgnoreMatcher.java
@@ -38,6 +38,11 @@ public class HypertraceGlobalIgnoreMatcher implements IgnoreMatcherProvider {
 
   @Override
   public Result classloader(ClassLoader classLoader) {
+    // bootstrap
+    if (classLoader == null) {
+      return Result.DEFAULT;
+    }
+
     String name = classLoader.getClass().getName();
     if (name.startsWith("com.singularity.")) {
       return Result.IGNORE;

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceGlobalIgnoreMatcher.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceGlobalIgnoreMatcher.java
@@ -38,6 +38,10 @@ public class HypertraceGlobalIgnoreMatcher implements IgnoreMatcherProvider {
 
   @Override
   public Result classloader(ClassLoader classLoader) {
+    String name = classLoader.getClass().getName();
+    if (name.startsWith("com.singularity.*")) {
+      return Result.IGNORE;
+    }
     return Result.DEFAULT;
   }
 }


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

This exception was logged when running alongside appD agent. The app continued to work fine.

```
[opentelemetry.auto.trace 2021-01-19 22:37:14:021 -0800] [main] ERROR io.opentelemetry.javaagent.tooling.HelperInjector - Error preparing helpers while processing class org.apache.http.impl.client.InternalHttpClient for apache-httpclient. Failed to inject helper classes into instance com.singularity.ee.agent.appagent.kernel.classloader.Post19AgentClassLoader@5606c0b
```