### PR TITLE
Fix servlet exception accessing inputstream before the application

### DIFF
--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/BodyCaptureAsyncListener.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/BodyCaptureAsyncListener.java
@@ -68,14 +68,16 @@ public class BodyCaptureAsyncListener implements AsyncListener {
   @Override
   public void onComplete(AsyncEvent event) {
     if (responseHandled.compareAndSet(false, true)) {
-      captureResponseData(event.getSuppliedResponse(), event.getSuppliedRequest());
+      captureResponseDataAndClearRequestBuffer(
+          event.getSuppliedResponse(), event.getSuppliedRequest());
     }
   }
 
   @Override
   public void onError(AsyncEvent event) {
     if (responseHandled.compareAndSet(false, true)) {
-      captureResponseData(event.getSuppliedResponse(), event.getSuppliedRequest());
+      captureResponseDataAndClearRequestBuffer(
+          event.getSuppliedResponse(), event.getSuppliedRequest());
     }
   }
 
@@ -85,7 +87,8 @@ public class BodyCaptureAsyncListener implements AsyncListener {
   @Override
   public void onStartAsync(AsyncEvent event) {}
 
-  private void captureResponseData(ServletResponse servletResponse, ServletRequest servletRequest) {
+  private void captureResponseDataAndClearRequestBuffer(
+      ServletResponse servletResponse, ServletRequest servletRequest) {
     if (servletResponse instanceof HttpServletResponse) {
       HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
 

--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/BodyCaptureAsyncListener.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/BodyCaptureAsyncListener.java
@@ -18,18 +18,24 @@ package io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowra
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.javaagent.instrumentation.api.ContextStore;
+import java.io.BufferedReader;
 import java.io.PrintWriter;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.servlet.AsyncEvent;
 import javax.servlet.AsyncListener;
+import javax.servlet.ServletInputStream;
 import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.hypertrace.agent.config.Config.AgentConfig;
 import org.hypertrace.agent.core.config.HypertraceConfig;
 import org.hypertrace.agent.core.instrumentation.HypertraceSemanticAttributes;
 import org.hypertrace.agent.core.instrumentation.buffer.BoundedByteArrayOutputStream;
 import org.hypertrace.agent.core.instrumentation.buffer.BoundedCharArrayWriter;
+import org.hypertrace.agent.core.instrumentation.buffer.ByteBufferSpanPair;
+import org.hypertrace.agent.core.instrumentation.buffer.CharBufferSpanPair;
 import org.hypertrace.agent.core.instrumentation.utils.ContentTypeUtils;
 
 public class BodyCaptureAsyncListener implements AsyncListener {
@@ -39,30 +45,37 @@ public class BodyCaptureAsyncListener implements AsyncListener {
   private final ContextStore<ServletOutputStream, BoundedByteArrayOutputStream> streamContextStore;
   private final ContextStore<PrintWriter, BoundedCharArrayWriter> writerContextStore;
 
+  private final ContextStore<ServletInputStream, ByteBufferSpanPair> inputStreamContext;
+  private final ContextStore<BufferedReader, CharBufferSpanPair> readerContext;
+
   private final AgentConfig agentConfig = HypertraceConfig.get();
 
   public BodyCaptureAsyncListener(
       AtomicBoolean responseHandled,
       Span span,
       ContextStore<ServletOutputStream, BoundedByteArrayOutputStream> streamContextStore,
-      ContextStore<PrintWriter, BoundedCharArrayWriter> writerContextStore) {
+      ContextStore<PrintWriter, BoundedCharArrayWriter> writerContextStore,
+      ContextStore<ServletInputStream, ByteBufferSpanPair> inputStreamContext,
+      ContextStore<BufferedReader, CharBufferSpanPair> readerContext) {
     this.responseHandled = responseHandled;
     this.span = span;
     this.streamContextStore = streamContextStore;
     this.writerContextStore = writerContextStore;
+    this.inputStreamContext = inputStreamContext;
+    this.readerContext = readerContext;
   }
 
   @Override
   public void onComplete(AsyncEvent event) {
     if (responseHandled.compareAndSet(false, true)) {
-      captureResponseData(event.getSuppliedResponse());
+      captureResponseData(event.getSuppliedResponse(), event.getSuppliedRequest());
     }
   }
 
   @Override
   public void onError(AsyncEvent event) {
     if (responseHandled.compareAndSet(false, true)) {
-      captureResponseData(event.getSuppliedResponse());
+      captureResponseData(event.getSuppliedResponse(), event.getSuppliedRequest());
     }
   }
 
@@ -72,7 +85,7 @@ public class BodyCaptureAsyncListener implements AsyncListener {
   @Override
   public void onStartAsync(AsyncEvent event) {}
 
-  private void captureResponseData(ServletResponse servletResponse) {
+  private void captureResponseData(ServletResponse servletResponse, ServletRequest servletRequest) {
     if (servletResponse instanceof HttpServletResponse) {
       HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
 
@@ -87,6 +100,15 @@ public class BodyCaptureAsyncListener implements AsyncListener {
           span.setAttribute(
               HypertraceSemanticAttributes.httpResponseHeader(headerName), headerValue);
         }
+      }
+    }
+    if (servletRequest instanceof HttpServletRequest) {
+      HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+
+      // remove request body buffers from context stores, otherwise they might get reused
+      if (agentConfig.getDataCapture().getHttpBody().getRequest().getValue()
+          && ContentTypeUtils.shouldCapture(httpRequest.getContentType())) {
+        Utils.resetRequestBodyBuffers(inputStreamContext, readerContext, httpRequest);
       }
     }
   }

--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet30NoWrappingInstrumentationTest.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet30NoWrappingInstrumentationTest.java
@@ -16,6 +16,8 @@
 
 package io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping;
 
+import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoAsyncResponse_stream;
+import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoAsyncResponse_writer;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoStream_arr;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoStream_arr_offset;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoStream_readLine_print;
@@ -63,12 +65,14 @@ public class Servlet30NoWrappingInstrumentationTest extends AbstractInstrumenter
     handler.addServlet(TestServlets.EchoWriter_arr.class, "/echo_writer_arr");
     handler.addServlet(TestServlets.EchoWriter_arr_offset.class, "/echo_writer_arr_offset");
     handler.addServlet(TestServlets.EchoWriter_readLine_write.class, "/echo_writer_readLine_write");
+    handler.addServlet(TestServlets.EchoWriter_readLines.class, "/echo_writer_readLines");
     handler.addServlet(
         TestServlets.EchoWriter_readLine_print_str.class, "/echo_writer_readLine_print_str");
     handler.addServlet(
         TestServlets.EchoWriter_readLine_print_arr.class, "/echo_writer_readLine_print_arr");
     handler.addServlet(TestServlets.Forward_to_post.class, "/forward_to_echo");
-    handler.addServlet(TestServlets.EchoAsyncResponse.class, "/echo_async_response");
+    handler.addServlet(EchoAsyncResponse_stream.class, "/echo_async_response_stream");
+    handler.addServlet(EchoAsyncResponse_writer.class, "/echo_async_response_writer");
     server.setHandler(handler);
     server.start();
     serverPort = server.getConnectors()[0].getLocalPort();
@@ -85,8 +89,13 @@ public class Servlet30NoWrappingInstrumentationTest extends AbstractInstrumenter
   }
 
   @Test
-  public void echo_async_response() throws Exception {
-    postJson(String.format("http://localhost:%d/echo_async_response", serverPort));
+  public void echo_async_response_stream() throws Exception {
+    postJson(String.format("http://localhost:%d/echo_async_response_stream", serverPort));
+  }
+
+  @Test
+  public void echo_async_response_writer() throws Exception {
+    postJson(String.format("http://localhost:%d/echo_async_response_writer", serverPort));
   }
 
   @Test
@@ -132,6 +141,11 @@ public class Servlet30NoWrappingInstrumentationTest extends AbstractInstrumenter
   @Test
   public void postJson_writer_readLine_print_str() throws Exception {
     postJson(String.format("http://localhost:%d/echo_writer_readLine_print_str", serverPort));
+  }
+
+  @Test
+  public void postJson_writer_readLines() throws Exception {
+    postJson(String.format("http://localhost:%d/echo_writer_readLines", serverPort));
   }
 
   @Test


### PR DESCRIPTION
This fixes accessing request inputstream/reader before the application for async requests. In other words the instrumentation could access input stream before the application - especially for async response.

This fixes the issue, however the instrumentation still tries to access the streams even though the application might not read the body at all. In the follow-up PR I will try to add a check to read the stream only if the app accessed it.

```
2021-01-25 05:35:34.391 [GraphQLServlet-4] INFO  g.k.s.HttpRequestHandlerImpl - Bad request: cannot create invocation input parser

java.lang.IllegalStateException: STREAMED

	at org.eclipse.jetty.server.Request.getReader(Request.java:1178) ~[jetty-server-9.4.30.v20200611.jar:9.4.30.v20200611]

	at graphql.kickstart.servlet.GraphQLPostInvocationInputParser.getGraphQLInvocationInput(GraphQLPostInvocationInputParser.java:33) ~[graphql-java-servlet-10.0.0.jar:?]

	at graphql.kickstart.servlet.HttpRequestHandlerImpl.handle(HttpRequestHandlerImpl.java:36) ~[graphql-java-servlet-10.0.0.jar:?]

	at graphql.kickstart.servlet.AbstractGraphQLHttpServlet.doRequest(AbstractGraphQLHttpServlet.java:148) ~[graphql-java-servlet-10.0.0.jar:?]

	at graphql.kickstart.servlet.AbstractGraphQLHttpServlet.lambda$doRequestAsync$2(AbstractGraphQLHttpServlet.java:136) ~[graphql-java-servlet-10.0.0.jar:?]

	at io.opentelemetry.javaagent.instrumentation.api.concurrent.RunnableWrapper.run(RunnableWrapper.java:28) [?:0.9.1]

	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:?]

	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:?]

	at java.lang.Thread.run(Unknown Source) [?:?]

```

Signed-off-by: Pavol Loffay <p.loffay@gmail.com>