### PR TITLE
Do not call get streams on request/response objects

### DIFF
--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/BodyCaptureAsyncListener.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/BodyCaptureAsyncListener.java
@@ -50,8 +50,8 @@ public class BodyCaptureAsyncListener implements AsyncListener {
   private final ContextStore<PrintWriter, BoundedCharArrayWriter> writerContextStore;
 
   private final ContextStore<HttpServletRequest, RequestStreamReaderHolder> requestContextStore;
-  private final ContextStore<ServletInputStream, ByteBufferSpanPair> inputStreamContext;
-  private final ContextStore<BufferedReader, CharBufferSpanPair> readerContext;
+  private final ContextStore<ServletInputStream, ByteBufferSpanPair> inputStreamContextStore;
+  private final ContextStore<BufferedReader, CharBufferSpanPair> readerContextStore;
 
   private final AgentConfig agentConfig = HypertraceConfig.get();
 
@@ -70,8 +70,8 @@ public class BodyCaptureAsyncListener implements AsyncListener {
     this.streamContextStore = streamContextStore;
     this.writerContextStore = writerContextStore;
     this.requestContextStore = requestContextStore;
-    this.inputStreamContext = inputStreamContextStore;
-    this.readerContext = readerContextStore;
+    this.inputStreamContextStore = inputStreamContextStore;
+    this.readerContextStore = readerContextStore;
   }
 
   @Override
@@ -122,7 +122,7 @@ public class BodyCaptureAsyncListener implements AsyncListener {
       if (agentConfig.getDataCapture().getHttpBody().getRequest().getValue()
           && ContentTypeUtils.shouldCapture(httpRequest.getContentType())) {
         Utils.resetRequestBodyBuffers(
-            httpRequest, requestContextStore, inputStreamContext, readerContext);
+            httpRequest, requestContextStore, inputStreamContextStore, readerContextStore);
       }
     }
   }

--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet31NoWrappingInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet31NoWrappingInstrumentation.java
@@ -28,9 +28,9 @@ import io.opentelemetry.javaagent.instrumentation.api.CallDepthThreadLocalMap;
 import io.opentelemetry.javaagent.instrumentation.api.ContextStore;
 import io.opentelemetry.javaagent.instrumentation.api.InstrumentationContext;
 import io.opentelemetry.javaagent.instrumentation.api.Java8BytecodeBridge;
+import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.request.RequestStreamReaderHolder;
 import io.opentelemetry.javaagent.tooling.TypeInstrumentation;
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -102,8 +102,8 @@ public class Servlet31NoWrappingInstrumentation implements TypeInstrumentation {
           && ContentTypeUtils.shouldCapture(contentType)) {
         // The HttpServletRequest instrumentation uses this to
         // enable the instrumentation
-        InstrumentationContext.get(HttpServletRequest.class, Span.class)
-            .put(httpRequest, currentSpan);
+        InstrumentationContext.get(HttpServletRequest.class, RequestStreamReaderHolder.class)
+            .put(httpRequest, new RequestStreamReaderHolder(currentSpan));
       }
 
       Utils.addSessionId(currentSpan, httpRequest);
@@ -135,8 +135,7 @@ public class Servlet31NoWrappingInstrumentation implements TypeInstrumentation {
     public static void exit(
         @Advice.Argument(0) ServletRequest request,
         @Advice.Argument(1) ServletResponse response,
-        @Advice.Local("currentSpan") Span currentSpan)
-        throws IOException {
+        @Advice.Local("currentSpan") Span currentSpan) {
       int callDepth =
           CallDepthThreadLocalMap.decrementCallDepth(Servlet31InstrumentationName.class);
       if (callDepth > 0) {
@@ -152,15 +151,17 @@ public class Servlet31NoWrappingInstrumentation implements TypeInstrumentation {
       HttpServletRequest httpRequest = (HttpServletRequest) request;
       AgentConfig agentConfig = HypertraceConfig.get();
 
-      ContextStore<ServletOutputStream, BoundedByteArrayOutputStream> outputStreamContext =
+      ContextStore<ServletOutputStream, BoundedByteArrayOutputStream> outputStreamContextStore =
           InstrumentationContext.get(ServletOutputStream.class, BoundedByteArrayOutputStream.class);
-      ContextStore<PrintWriter, BoundedCharArrayWriter> writerContext =
+      ContextStore<PrintWriter, BoundedCharArrayWriter> writerContextStore =
           InstrumentationContext.get(PrintWriter.class, BoundedCharArrayWriter.class);
 
       // request context to clear body buffer
-      ContextStore<ServletInputStream, ByteBufferSpanPair> inputStreamContext =
+      ContextStore<HttpServletRequest, RequestStreamReaderHolder> requestContextStore =
+          InstrumentationContext.get(HttpServletRequest.class, RequestStreamReaderHolder.class);
+      ContextStore<ServletInputStream, ByteBufferSpanPair> inputStreamContextStore =
           InstrumentationContext.get(ServletInputStream.class, ByteBufferSpanPair.class);
-      ContextStore<BufferedReader, CharBufferSpanPair> readerContext =
+      ContextStore<BufferedReader, CharBufferSpanPair> readerContextStore =
           InstrumentationContext.get(BufferedReader.class, CharBufferSpanPair.class);
 
       AtomicBoolean responseHandled = new AtomicBoolean(false);
@@ -172,10 +173,11 @@ public class Servlet31NoWrappingInstrumentation implements TypeInstrumentation {
                   new BodyCaptureAsyncListener(
                       responseHandled,
                       currentSpan,
-                      outputStreamContext,
-                      writerContext,
-                      inputStreamContext,
-                      readerContext));
+                      outputStreamContextStore,
+                      writerContextStore,
+                      requestContextStore,
+                      inputStreamContextStore,
+                      readerContextStore));
         } catch (IllegalStateException e) {
           // org.eclipse.jetty.server.Request may throw an exception here if request became
           // finished after check above. We just ignore that exception and move on.
@@ -194,13 +196,15 @@ public class Servlet31NoWrappingInstrumentation implements TypeInstrumentation {
         // capture response body
         if (agentConfig.getDataCapture().getHttpBody().getResponse().getValue()
             && ContentTypeUtils.shouldCapture(httpResponse.getContentType())) {
-          Utils.captureResponseBody(currentSpan, outputStreamContext, writerContext, httpResponse);
+          Utils.captureResponseBody(
+              currentSpan, outputStreamContextStore, writerContextStore, httpResponse);
         }
 
         // remove request body buffers from context stores, otherwise they might get reused
         if (agentConfig.getDataCapture().getHttpBody().getRequest().getValue()
             && ContentTypeUtils.shouldCapture(httpRequest.getContentType())) {
-          Utils.resetRequestBodyBuffers(inputStreamContext, readerContext, httpRequest);
+          Utils.resetRequestBodyBuffers(
+              httpRequest, requestContextStore, inputStreamContextStore, readerContextStore);
         }
       }
     }

--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet31NoWrappingInstrumentationModule.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet31NoWrappingInstrumentationModule.java
@@ -22,6 +22,7 @@ import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.request.RequestStreamReaderHolder;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.request.ServletInputStreamInstrumentation;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.request.ServletRequestInstrumentation;
+import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.response.ResponseStreamWriterHolder;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.response.ServletOutputStreamInstrumentation;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.response.ServletResponseInstrumentation;
 import io.opentelemetry.javaagent.tooling.InstrumentationModule;
@@ -72,6 +73,8 @@ public class Servlet31NoWrappingInstrumentationModule extends InstrumentationMod
     context.put("java.io.BufferedReader", CharBufferSpanPair.class.getName());
 
     // capture response body
+    context.put(
+        "javax.servlet.http.HttpServletResponse", ResponseStreamWriterHolder.class.getName());
     context.put("javax.servlet.ServletOutputStream", BoundedByteArrayOutputStream.class.getName());
     context.put("java.io.PrintWriter", BoundedCharArrayWriter.class.getName());
     return context;

--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet31NoWrappingInstrumentationModule.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet31NoWrappingInstrumentationModule.java
@@ -19,7 +19,7 @@ package io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowra
 import static io.opentelemetry.javaagent.tooling.bytebuddy.matcher.ClassLoaderMatcher.hasClassesNamed;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.request.RequestStreamReaderHolder;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.request.ServletInputStreamInstrumentation;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.request.ServletRequestInstrumentation;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.response.ServletOutputStreamInstrumentation;
@@ -67,7 +67,7 @@ public class Servlet31NoWrappingInstrumentationModule extends InstrumentationMod
   protected Map<String, String> contextStore() {
     Map<String, String> context = new HashMap<>();
     // capture request body
-    context.put("javax.servlet.http.HttpServletRequest", Span.class.getName());
+    context.put("javax.servlet.http.HttpServletRequest", RequestStreamReaderHolder.class.getName());
     context.put("javax.servlet.ServletInputStream", ByteBufferSpanPair.class.getName());
     context.put("java.io.BufferedReader", CharBufferSpanPair.class.getName());
 

--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Utils.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Utils.java
@@ -59,6 +59,7 @@ public class Utils {
     if (responseStreamWriterHolder == null) {
       return;
     }
+    responseContextStore.put(httpServletResponse, null);
 
     if (responseStreamWriterHolder.getServletOutputStream() != null) {
       ServletOutputStream servletOutputStream = responseStreamWriterHolder.getServletOutputStream();

--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/request/RequestStreamReaderHolder.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/request/RequestStreamReaderHolder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.request;
+
+import io.opentelemetry.api.trace.Span;
+import java.io.BufferedReader;
+import javax.servlet.ServletInputStream;
+
+public class RequestStreamReaderHolder {
+
+  private final Span span;
+  private ServletInputStream servletInputStream;
+  private BufferedReader bufferedReader;
+
+  public RequestStreamReaderHolder(Span span) {
+    this.span = span;
+  }
+
+  public Span getSpan() {
+    return span;
+  }
+
+  public ServletInputStream getServletInputStream() {
+    return servletInputStream;
+  }
+
+  public void setServletInputStream(ServletInputStream servletInputStream) {
+    this.servletInputStream = servletInputStream;
+  }
+
+  public BufferedReader getBufferedReader() {
+    return bufferedReader;
+  }
+
+  public void setBufferedReader(BufferedReader bufferedReader) {
+    this.bufferedReader = bufferedReader;
+  }
+}

--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/request/ServletRequestInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/request/ServletRequestInstrumentation.java
@@ -86,6 +86,7 @@ public class ServletRequestInstrumentation implements TypeInstrumentation {
     public static void exit(
         @Advice.This ServletRequest servletRequest,
         @Advice.Return ServletInputStream servletInputStream,
+        @Advice.Thrown Throwable throwable,
         @Advice.Enter RequestStreamReaderHolder requestStreamReaderHolder) {
 
       if (requestStreamReaderHolder == null) {
@@ -96,9 +97,8 @@ public class ServletRequestInstrumentation implements TypeInstrumentation {
       if (callDepth > 0) {
         return;
       }
-      // TODO what to do on exception?
 
-      if (!(servletRequest instanceof HttpServletRequest)) {
+      if (!(servletRequest instanceof HttpServletRequest) || throwable != null) {
         return;
       }
       HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
@@ -137,6 +137,7 @@ public class ServletRequestInstrumentation implements TypeInstrumentation {
     public static void exit(
         @Advice.This ServletRequest servletRequest,
         @Advice.Return BufferedReader reader,
+        @Advice.Thrown Throwable throwable,
         @Advice.Enter RequestStreamReaderHolder requestStreamReaderHolder) {
 
       if (requestStreamReaderHolder == null) {
@@ -148,7 +149,7 @@ public class ServletRequestInstrumentation implements TypeInstrumentation {
         return;
       }
 
-      if (!(servletRequest instanceof HttpServletRequest)) {
+      if (!(servletRequest instanceof HttpServletRequest) || throwable != null) {
         return;
       }
       HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;

--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/request/ServletRequestInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/request/ServletRequestInstrumentation.java
@@ -22,7 +22,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.javaagent.instrumentation.api.CallDepthThreadLocalMap;
 import io.opentelemetry.javaagent.instrumentation.api.ContextStore;
 import io.opentelemetry.javaagent.instrumentation.api.InstrumentationContext;
@@ -68,27 +67,28 @@ public class ServletRequestInstrumentation implements TypeInstrumentation {
 
   static class ServletRequest_getInputStream_advice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Span enter(@Advice.This ServletRequest servletRequest) {
+    public static RequestStreamReaderHolder enter(@Advice.This ServletRequest servletRequest) {
       HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
       // span is added in servlet/filter instrumentation if data capture is enabled
-      Span requestSpan =
-          InstrumentationContext.get(HttpServletRequest.class, Span.class).get(httpServletRequest);
-      if (requestSpan == null) {
+      RequestStreamReaderHolder requestBufferWrapper =
+          InstrumentationContext.get(HttpServletRequest.class, RequestStreamReaderHolder.class)
+              .get(httpServletRequest);
+      if (requestBufferWrapper == null) {
         return null;
       }
 
       // the getReader method might call getInputStream
       CallDepthThreadLocalMap.incrementCallDepth(ServletRequest.class);
-      return requestSpan;
+      return requestBufferWrapper;
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
     public static void exit(
         @Advice.This ServletRequest servletRequest,
         @Advice.Return ServletInputStream servletInputStream,
-        @Advice.Enter Span requestSpan) {
+        @Advice.Enter RequestStreamReaderHolder requestStreamReaderHolder) {
 
-      if (requestSpan == null) {
+      if (requestStreamReaderHolder == null) {
         return;
       }
 
@@ -96,6 +96,7 @@ public class ServletRequestInstrumentation implements TypeInstrumentation {
       if (callDepth > 0) {
         return;
       }
+      // TODO what to do on exception?
 
       if (!(servletRequest instanceof HttpServletRequest)) {
         return;
@@ -110,32 +111,35 @@ public class ServletRequestInstrumentation implements TypeInstrumentation {
       }
 
       ByteBufferSpanPair bufferSpanPair =
-          Utils.createRequestByteBufferSpanPair(httpServletRequest, requestSpan);
+          Utils.createRequestByteBufferSpanPair(
+              httpServletRequest, requestStreamReaderHolder.getSpan());
       contextStore.put(servletInputStream, bufferSpanPair);
+      requestStreamReaderHolder.setServletInputStream(servletInputStream);
     }
   }
 
   static class ServletRequest_getReader_advice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Span enter(@Advice.This ServletRequest servletRequest) {
+    public static RequestStreamReaderHolder enter(@Advice.This ServletRequest servletRequest) {
       HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
-      Span requestSpan =
-          InstrumentationContext.get(HttpServletRequest.class, Span.class).get(httpServletRequest);
-      if (requestSpan == null) {
+      RequestStreamReaderHolder requestStreamReaderHolder =
+          InstrumentationContext.get(HttpServletRequest.class, RequestStreamReaderHolder.class)
+              .get(httpServletRequest);
+      if (requestStreamReaderHolder == null) {
         return null;
       }
 
       CallDepthThreadLocalMap.incrementCallDepth(ServletRequest.class);
-      return requestSpan;
+      return requestStreamReaderHolder;
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
     public static void exit(
         @Advice.This ServletRequest servletRequest,
         @Advice.Return BufferedReader reader,
-        @Advice.Enter Span requestSpan) {
+        @Advice.Enter RequestStreamReaderHolder requestStreamReaderHolder) {
 
-      if (requestSpan == null) {
+      if (requestStreamReaderHolder == null) {
         return;
       }
 
@@ -157,8 +161,10 @@ public class ServletRequestInstrumentation implements TypeInstrumentation {
       }
 
       CharBufferSpanPair bufferSpanPair =
-          Utils.createRequestCharBufferSpanPair(httpServletRequest, requestSpan);
+          Utils.createRequestCharBufferSpanPair(
+              httpServletRequest, requestStreamReaderHolder.getSpan());
       contextStore.put(reader, bufferSpanPair);
+      requestStreamReaderHolder.setBufferedReader(reader);
     }
   }
 }

--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/response/ResponseStreamWriterHolder.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/response/ResponseStreamWriterHolder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.response;
+
+import java.io.PrintWriter;
+import javax.servlet.ServletOutputStream;
+
+public class ResponseStreamWriterHolder {
+
+  private final ServletOutputStream servletOutputStream;
+  private final PrintWriter printWriter;
+
+  public ResponseStreamWriterHolder(ServletOutputStream servletOutputStream) {
+    this.servletOutputStream = servletOutputStream;
+    this.printWriter = null;
+  }
+
+  public ResponseStreamWriterHolder(PrintWriter printWriter) {
+    this.printWriter = printWriter;
+    this.servletOutputStream = null;
+  }
+
+  public ServletOutputStream getServletOutputStream() {
+    return servletOutputStream;
+  }
+
+  public PrintWriter getPrintWriter() {
+    return printWriter;
+  }
+}

--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/response/ServletResponseInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/response/ServletResponseInstrumentation.java
@@ -92,6 +92,7 @@ public class ServletResponseInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
     public static void exit(
         @Advice.Enter HttpServletResponse httpServletResponse,
+        @Advice.Thrown Throwable throwable,
         @Advice.Return ServletOutputStream servletOutputStream) {
 
       if (httpServletResponse == null) {
@@ -100,6 +101,9 @@ public class ServletResponseInstrumentation implements TypeInstrumentation {
 
       int callDepth = CallDepthThreadLocalMap.decrementCallDepth(ServletResponse.class);
       if (callDepth > 0) {
+        return;
+      }
+      if (throwable != null) {
         return;
       }
 
@@ -120,7 +124,8 @@ public class ServletResponseInstrumentation implements TypeInstrumentation {
         Charset charset = ContentTypeCharsetUtils.toCharset(charsetStr);
         BoundedByteArrayOutputStream buffer = BoundedBuffersFactory.createStream(charset);
         contextStore.put(servletOutputStream, buffer);
-        // override the metadata that is used by the OutputStream instrumentation
+        InstrumentationContext.get(HttpServletResponse.class, ResponseStreamWriterHolder.class)
+            .put(httpServletResponse, new ResponseStreamWriterHolder(servletOutputStream));
       }
     }
   }
@@ -144,6 +149,7 @@ public class ServletResponseInstrumentation implements TypeInstrumentation {
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
     public static void exit(
         @Advice.Enter HttpServletResponse httpServletResponse,
+        @Advice.Thrown Throwable throwable,
         @Advice.Return PrintWriter printWriter) {
 
       if (httpServletResponse == null) {
@@ -152,6 +158,9 @@ public class ServletResponseInstrumentation implements TypeInstrumentation {
 
       int callDepth = CallDepthThreadLocalMap.decrementCallDepth(ServletResponse.class);
       if (callDepth > 0) {
+        return;
+      }
+      if (throwable != null) {
         return;
       }
 
@@ -170,6 +179,8 @@ public class ServletResponseInstrumentation implements TypeInstrumentation {
 
         BoundedCharArrayWriter writer = BoundedBuffersFactory.createWriter();
         contextStore.put(printWriter, writer);
+        InstrumentationContext.get(HttpServletResponse.class, ResponseStreamWriterHolder.class)
+            .put(httpServletResponse, new ResponseStreamWriterHolder(printWriter));
       }
     }
   }


### PR DESCRIPTION
Properly fixes https://github.com/hypertrace/javaagent/pull/242 by avoiding calls to get stream/reader if it wasn't called.

Signed-off-by: Pavol Loffay <p.loffay@gmail.com>