### PR TITLE
lowercase all http header and rpc metadata keys

### DIFF
--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/instrumentation/HypertraceSemanticAttributes.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/instrumentation/HypertraceSemanticAttributes.java
@@ -30,11 +30,11 @@ public class HypertraceSemanticAttributes {
   public static final String ADDITIONAL_DATA_SPAN_NAME = "additional-data";
 
   public static AttributeKey<String> httpRequestHeader(String header) {
-    return AttributeKey.stringKey("http.request.header." + header);
+    return AttributeKey.stringKey("http.request.header." + header.toLowerCase());
   }
 
   public static AttributeKey<String> httpResponseHeader(String header) {
-    return AttributeKey.stringKey("http.response.header." + header);
+    return AttributeKey.stringKey("http.response.header." + header.toLowerCase());
   }
 
   public static final AttributeKey<String> HTTP_REQUEST_BODY =
@@ -51,10 +51,10 @@ public class HypertraceSemanticAttributes {
       AttributeKey.stringKey("rpc.response.body");
 
   public static final AttributeKey<String> rpcRequestMetadata(String key) {
-    return AttributeKey.stringKey("rpc.request.metadata." + key);
+    return AttributeKey.stringKey("rpc.request.metadata." + key.toLowerCase());
   }
 
   public static final AttributeKey<String> rpcResponseMetadata(String key) {
-    return AttributeKey.stringKey("rpc.response.metadata." + key);
+    return AttributeKey.stringKey("rpc.response.metadata." + key.toLowerCase());
   }
 }

--- a/javaagent-core/src/test/java/org/hypertrace/agent/core/instrumentation/HypertraceSemanticAttributesTest.java
+++ b/javaagent-core/src/test/java/org/hypertrace/agent/core/instrumentation/HypertraceSemanticAttributesTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.core.instrumentation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class HypertraceSemanticAttributesTest {
+
+  @Test
+  public void caseInsensitiveHttpRequestHeader() {
+    Assertions.assertEquals(
+        "http.request.header.content-type",
+        HypertraceSemanticAttributes.httpRequestHeader("Content-Type").getKey());
+  }
+
+  @Test
+  public void caseInsensitiveHttpResponseHeader() {
+    Assertions.assertEquals(
+        "http.response.header.content-type",
+        HypertraceSemanticAttributes.httpResponseHeader("Content-Type").getKey());
+  }
+
+  @Test
+  public void caseInsensitiveRpcRequestMetadata() {
+    Assertions.assertEquals(
+        "rpc.request.metadata.md", HypertraceSemanticAttributes.rpcRequestMetadata("MD").getKey());
+  }
+
+  @Test
+  public void caseInsensitiveRpcResponseMetadata() {
+    Assertions.assertEquals(
+        "rpc.response.metadata.md",
+        HypertraceSemanticAttributes.rpcResponseMetadata("MD").getKey());
+  }
+}


### PR DESCRIPTION
For consistent lookup of http headers and rpc metadata in the span attribute map, we should always lower case them.

This allows collector processors to lookup headers without having to pre-process the span.