### PR TITLE
Remove HT config from bootstrap and app classloader

### DIFF
--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
     // https://oss.jfrog.org/artifactory/oss-snapshot-local/io/opentelemetry/instrumentation/auto/
     // https://dl.bintray.com/open-telemetry/maven/
     implementation("io.opentelemetry.javaagent", "opentelemetry-javaagent", version = "${versions["opentelemetry_java_agent"]}", classifier = "all")
-    implementation(project(":javaagent-core"))
     implementation(project(":filter-api"))
 }
 
@@ -50,8 +49,7 @@ tasks {
         }
 
         relocate("org.slf4j", "io.opentelemetry.javaagent.slf4j")
-        // TODO causes data not being reported
-//        relocate("java.util.logging.Logger", "io.opentelemetry.javaagent.bootstrap.PatchLogger")
+        relocate("java.util.logging.Logger", "io.opentelemetry.javaagent.bootstrap.PatchLogger")
 
         // prevents conflict with library instrumentation
         relocate("io.opentelemetry.instrumentation.api", "io.opentelemetry.javaagent.shaded.instrumentation.api")

--- a/javaagent/src/main/java/org/hypertrace/agent/instrument/HypertraceAgent.java
+++ b/javaagent/src/main/java/org/hypertrace/agent/instrument/HypertraceAgent.java
@@ -16,28 +16,13 @@
 
 package org.hypertrace.agent.instrument;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.javaagent.OpenTelemetryAgent;
 import java.lang.instrument.Instrumentation;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import org.hypertrace.agent.config.Config.AgentConfig;
-import org.hypertrace.agent.config.Config.PropagationFormat;
-import org.hypertrace.agent.core.config.HypertraceConfig;
 
 public class HypertraceAgent {
-  // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-environment-variables.md
-  private static final String OTEL_EXPORTER = "otel.exporter";
-  private static final String OTEL_PROPAGATORS = "otel.propagators";
-  private static final String OTEL_EXPORTER_ZIPKIN_ENDPOINT = "otel.exporter.zipkin.endpoint";
-  private static final String OTEL_EXPORTER_ZIPKIN_SERVICE_NAME =
-      "otel.exporter.zipkin.service.name";
-  private static final String OTEL_PROCESSOR_BATCH_MAX_QUEUE = "otel.bsp.max.queue.size";
-  private static final String OTEL_DEFAULT_LOG_LEVEL =
-      "io.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel";
 
   private static HypertraceAgent instance;
 
@@ -64,32 +49,10 @@ public class HypertraceAgent {
     }
 
     instance = new HypertraceAgent();
-    setDefaultConfig();
     OpenTelemetryAgent.premain(agentArgs, inst);
     System.out.printf(
         "Hypertrace agent started, version: %s\n",
         HypertraceAgent.class.getPackage().getImplementationVersion());
-  }
-
-  /** Set default values to OTEL config. OTEL config has a higher precedence. */
-  private static void setDefaultConfig() {
-    AgentConfig agentConfig = HypertraceConfig.get();
-    OpenTelemetryConfig.setDefault(OTEL_EXPORTER, "zipkin");
-    OpenTelemetryConfig.setDefault(
-        OTEL_EXPORTER_ZIPKIN_SERVICE_NAME, agentConfig.getServiceName().getValue());
-    OpenTelemetryConfig.setDefault(
-        OTEL_PROPAGATORS, toOtelPropagators(agentConfig.getPropagationFormatsList()));
-    OpenTelemetryConfig.setDefault(
-        OTEL_EXPORTER_ZIPKIN_ENDPOINT, agentConfig.getReporting().getEndpoint().getValue());
-    OpenTelemetryConfig.setDefault(
-        OTEL_EXPORTER_ZIPKIN_SERVICE_NAME, agentConfig.getServiceName().getValue());
-  }
-
-  @VisibleForTesting
-  static String toOtelPropagators(List<PropagationFormat> propagationFormats) {
-    return propagationFormats.stream()
-        .map(v -> v.name().toLowerCase())
-        .collect(Collectors.joining(","));
   }
 
   // Expected format is "arg1=val1,arg2=val2,arg3=val3"

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceAgentConfiguration.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceAgentConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.otel.extensions;
+
+import com.google.auto.service.AutoService;
+import com.google.common.annotations.VisibleForTesting;
+import io.opentelemetry.javaagent.spi.config.PropertySource;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.hypertrace.agent.config.Config.AgentConfig;
+import org.hypertrace.agent.config.Config.PropagationFormat;
+import org.hypertrace.agent.core.config.HypertraceConfig;
+
+@AutoService(PropertySource.class)
+public class HypertraceAgentConfiguration implements PropertySource {
+
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-environment-variables.md
+  private static final String OTEL_EXPORTER = "otel.exporter";
+  private static final String OTEL_PROPAGATORS = "otel.propagators";
+  private static final String OTEL_EXPORTER_ZIPKIN_ENDPOINT = "otel.exporter.zipkin.endpoint";
+  private static final String OTEL_EXPORTER_ZIPKIN_SERVICE_NAME =
+      "otel.exporter.zipkin.service.name";
+  private static final String OTEL_PROCESSOR_BATCH_MAX_QUEUE = "otel.bsp.max.queue.size";
+  private static final String OTEL_DEFAULT_LOG_LEVEL =
+      "io.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel";
+
+  @Override
+  public Map<String, String> getProperties() {
+    AgentConfig agentConfig = HypertraceConfig.get();
+
+    Map<String, String> configProperties = new HashMap<>();
+    configProperties.put(OTEL_EXPORTER, "zipkin");
+    configProperties.put(
+        OTEL_EXPORTER_ZIPKIN_SERVICE_NAME, agentConfig.getServiceName().getValue());
+    configProperties.put(
+        OTEL_EXPORTER_ZIPKIN_ENDPOINT, agentConfig.getReporting().getEndpoint().getValue());
+    configProperties.put(
+        OTEL_PROPAGATORS, toOtelPropagators(agentConfig.getPropagationFormatsList()));
+
+    return configProperties;
+  }
+
+  @VisibleForTesting
+  static String toOtelPropagators(List<PropagationFormat> propagationFormats) {
+    return propagationFormats.stream()
+        .map(v -> v.name().toLowerCase())
+        .collect(Collectors.joining(","));
+  }
+}

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/HypertraceTracerCustomizer.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/HypertraceTracerCustomizer.java
@@ -33,9 +33,6 @@ public class HypertraceTracerCustomizer implements TracerCustomizer {
 
   @Override
   public void configure(SdkTracerManagement tracerManagement) {
-    String exporter = System.getProperty("otel.exporter");
-    if (exporter != null && exporter.contains("zipkin")) {
-      tracerManagement.addSpanProcessor(new AddTagsSpanProcessor());
-    }
+    tracerManagement.addSpanProcessor(new AddTagsSpanProcessor());
   }
 }

--- a/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/HypertraceAgentConfigurationTest.java
+++ b/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/HypertraceAgentConfigurationTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.hypertrace.agent.instrument;
+package org.hypertrace.agent.otel.extensions;
 
 import java.util.Arrays;
 import java.util.List;
@@ -22,12 +22,13 @@ import org.hypertrace.agent.config.Config.PropagationFormat;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class HypertraceAgentTest {
+public class HypertraceAgentConfigurationTest {
 
   @Test
   public void propagationFormatList() {
     List<PropagationFormat> formats =
         Arrays.asList(PropagationFormat.B3, PropagationFormat.TRACECONTEXT);
-    Assertions.assertEquals("b3,tracecontext", HypertraceAgent.toOtelPropagators(formats));
+    Assertions.assertEquals(
+        "b3,tracecontext", HypertraceAgentConfiguration.toOtelPropagators(formats));
   }
 }


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

This PR removes the dependency on agent-core from javaagent, this results in:
* HT config (and its deps) is now located only in agent classloader (a better isolation)
* HT config (and its deps) is removed from app classloader and bootstrap cl.

on Wildfly this was causing 

```
Feb 08, 2021 1:31:55 PM org.jboss.as.controller.AbstractOperationContext executeStep
ERROR: WFLYCTL0013: Operation ("parallel-extension-add") failed - address: ([])
java.lang.RuntimeException: WFLYCTL0079: Failed initializing module org.jboss.as.logging
at org.jboss.as.controller.extension.ParallelExtensionAddHandler$1.execute(ParallelExtensionAddHandler.java:115)
at org.jboss.as.controller.AbstractOperationContext.executeStep(AbstractOperationContext.java:890)
at org.jboss.as.controller.AbstractOperationContext.processStages(AbstractOperationContext.java:659)
at org.jboss.as.controller.AbstractOperationContext.executeOperation(AbstractOperationContext.java:370)
at org.jboss.as.controller.OperationContextImpl.executeOperation(OperationContextImpl.java:1329)
at org.jboss.as.controller.ModelControllerImpl.boot(ModelControllerImpl.java:467)
at org.jboss.as.controller.AbstractControllerService.boot(AbstractControllerService.java:387)
at org.jboss.as.controller.AbstractControllerService.boot(AbstractControllerService.java:349)
at org.jboss.as.server.ServerService.boot(ServerService.java:397)
at org.jboss.as.server.ServerService.boot(ServerService.java:366)
at org.jboss.as.controller.AbstractControllerService$1.run(AbstractControllerService.java:299)
at java.lang.Thread.run(Thread.java:748)
Caused by: java.util.concurrent.ExecutionException: java.lang.IllegalStateException: WFLYLOG0078: The logging subsystem requires the log manager to be org.jboss.logmanager.LogManager. The subsystem has not be initialized and cannot be used. To use JBoss Log Manager you must add the system property "java.util.logging.manager" and set it to "org.jboss.logmanager.LogManager"
at java.util.concurrent.FutureTask.report(FutureTask.java:122)
at java.util.concurrent.FutureTask.get(FutureTask.java:192)
at org.jboss.as.controller.extension.ParallelExtensionAddHandler$1.execute(ParallelExtensionAddHandler.java:107)
... 11 more
Caused by: java.lang.IllegalStateException: WFLYLOG0078: The logging subsystem requires the log manager to be org.jboss.logmanager.LogManager. The subsystem has not be initialized and cannot be used. To use JBoss Log Manager you must add the system property "java.util.logging.manager" and set it to "org.jboss.logmanager.LogManager"
at org.jboss.as.logging.LoggingExtension.initialize(LoggingExtension.java:147)
at org.jboss.as.controller.extension.ExtensionAddHandler.initializeExtension(ExtensionAddHandler.java:131)
at org.jboss.as.controller.extension.ExtensionAddHandler.initializeExtension(ExtensionAddHandler.java:104)
at org.jboss.as.controller.extension.ParallelExtensionAddHandler$ExtensionInitializeTask.call(ParallelExtensionAddHandler.java:144)
at org.jboss.as.controller.extension.ParallelExtensionAddHandler$ExtensionInitializeTask.call(ParallelExtensionAddHandler.java:127)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
at org.jboss.threads.JBossThread.run(JBossThread.java:320)

Feb 08, 2021 1:31:55 PM org.jboss.as.server.ServerService$4 logExit
FATAL: WFLYSRV0056: Server boot has failed in an unrecoverable manner; exiting. See previous messages for details.
[opentelemetry.auto.trace 2021-02-08 13:31:55:221 -0700] [pool-1-thread-1] WARN io.opentelemetry.javaagent.tooling.CommonTaskExecutor - Periodic task scheduler is shutdown. Will not run: cleaner for {}
```