### PR TITLE
handle .scope postfix when parsing cgroup

### DIFF
--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/CgroupsReader.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/CgroupsReader.java
@@ -51,6 +51,9 @@ public class CgroupsReader {
     try (BufferedReader br = new BufferedReader(new FileReader(cgroupsPath))) {
       String line;
       while ((line = br.readLine()) != null) {
+        if (line.endsWith(".scope")) {
+          line = line.substring(0, line.length() - ".scope".length());
+        }
         if (line.length() > CONTAINER_ID_LENGTH) {
           String id = line.substring(line.length() - CONTAINER_ID_LENGTH);
           if (!id.contains("/")) {

--- a/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/DockerCgroupsReaderTest.java
+++ b/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/DockerCgroupsReaderTest.java
@@ -42,4 +42,16 @@ public class DockerCgroupsReaderTest {
     CgroupsReader cgroupsReader = new CgroupsReader(file.getPath());
     Assertions.assertEquals(expected, cgroupsReader.readContainerId());
   }
+
+  @Test
+  void readScopedContainerId(@TempDir File tempFolder) throws IOException {
+    File file = new File(tempFolder, "cgroup");
+    String expected = "736665661f3cf3ec691b2feeb2a1ec78918c0ef65381160bbb04f4c298169679";
+    String content =
+        "1:name=systemd:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podab2df320_6a91_4bc7_bd18_0d4328f04a8f.slice/crio-736665661f3cf3ec691b2feeb2a1ec78918c0ef65381160bbb04f4c298169679.scope";
+    Files.write(content.getBytes(Charsets.UTF_8), file);
+
+    CgroupsReader cgroupsReader = new CgroupsReader(file.getPath());
+    Assertions.assertEquals(expected, cgroupsReader.readContainerId());
+  }
 }


### PR DESCRIPTION
## Description

While parsing /proc/self/cgroup to obtain the containerId, it's possible there is a `.scope` postfix, such as `crio-736665661f3cf3ec691b2feeb2a1ec78918c0ef65381160bbb04f4c298169679.scope` which breaks our current parser.

### Testing
Tested in openshift and gke clusters

### Checklist:
- [X ] My changes generate no new warnings
- [X ] I have added tests that prove my fix is effective or that my feature works
- [X ] Any dependent changes have been merged and published in downstream modules

