### PR TITLE
Capture servlet request bodies explicitly

### DIFF
--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet30NoWrappingInstrumentationTest.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet30NoWrappingInstrumentationTest.java
@@ -18,9 +18,11 @@ package io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowra
 
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoAsyncResponse_stream;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoAsyncResponse_writer;
+import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoReader_read_large_array;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoStream_arr;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoStream_arr_offset;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoStream_readLine_print;
+import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoStream_read_large_array;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoStream_single_byte;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.EchoWriter_single_char;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.servlet.v3_0.nowrapping.TestServlets.GetHello;
@@ -73,6 +75,8 @@ public class Servlet30NoWrappingInstrumentationTest extends AbstractInstrumenter
     handler.addServlet(TestServlets.Forward_to_post.class, "/forward_to_echo");
     handler.addServlet(EchoAsyncResponse_stream.class, "/echo_async_response_stream");
     handler.addServlet(EchoAsyncResponse_writer.class, "/echo_async_response_writer");
+    handler.addServlet(EchoStream_read_large_array.class, "/echo_stream_read_large_array");
+    handler.addServlet(EchoReader_read_large_array.class, "/echo_reader_read_large_array");
     server.setHandler(handler);
     server.start();
     serverPort = server.getConnectors()[0].getLocalPort();
@@ -101,6 +105,16 @@ public class Servlet30NoWrappingInstrumentationTest extends AbstractInstrumenter
   @Test
   public void postJson_stream_single_byte() throws Exception {
     postJson(String.format("http://localhost:%d/echo_stream_single_byte", serverPort));
+  }
+
+  @Test
+  public void postJson_stream_read_large_array() throws Exception {
+    postJson(String.format("http://localhost:%d/echo_stream_read_large_array", serverPort));
+  }
+
+  @Test
+  public void postJson_reader_read_large_array() throws Exception {
+    postJson(String.format("http://localhost:%d/echo_reader_read_large_array", serverPort));
   }
 
   @Test

--- a/instrumentation/servlet/servlet-3.0-no-wrapping/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/TestServlets.java
+++ b/instrumentation/servlet/servlet-3.0-no-wrapping/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/TestServlets.java
@@ -265,4 +265,30 @@ public class TestServlets {
       req.getRequestDispatcher("/echo_stream_single_byte").forward(req, resp);
     }
   }
+
+  public static class EchoStream_read_large_array extends HttpServlet {
+    @Override
+    protected void service(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+      req.getInputStream().read(new byte[1000], 0, 1000);
+
+      resp.setStatus(200);
+      resp.setContentType("application/json");
+      resp.setHeader(RESPONSE_HEADER, RESPONSE_HEADER_VALUE);
+
+      resp.getWriter().print(RESPONSE_BODY.toCharArray());
+    }
+  }
+
+  public static class EchoReader_read_large_array extends HttpServlet {
+    @Override
+    protected void service(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+      req.getReader().read(new char[1000], 0, 1000);
+
+      resp.setStatus(200);
+      resp.setContentType("application/json");
+      resp.setHeader(RESPONSE_HEADER, RESPONSE_HEADER_VALUE);
+
+      resp.getWriter().print(RESPONSE_BODY.toCharArray());
+    }
+  }
 }


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Capture request body explicitly, some APIs (e.g. jackson) do not call stream#read until it returns -1 nor call stream#available.  