### PR TITLE
Add reporter type config option

### DIFF
--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/config/EnvironmentConfig.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/config/EnvironmentConfig.java
@@ -27,6 +27,7 @@ import org.hypertrace.agent.config.Config.Opa;
 import org.hypertrace.agent.config.Config.Opa.Builder;
 import org.hypertrace.agent.config.Config.PropagationFormat;
 import org.hypertrace.agent.config.Config.Reporting;
+import org.hypertrace.agent.config.Config.TraceReporterType;
 
 public class EnvironmentConfig {
 
@@ -42,6 +43,7 @@ public class EnvironmentConfig {
 
   private static final String REPORTING_PREFIX = HT_PREFIX + "reporting.";
   static final String REPORTING_ENDPOINT = REPORTING_PREFIX + "endpoint";
+  static final String REPORTING_TRACE_TYPE = REPORTING_PREFIX + "trace.reporter.type";
   static final String REPORTING_SECURE = REPORTING_PREFIX + "secure";
 
   private static final String OPA_PREFIX = REPORTING_PREFIX + "opa.";
@@ -108,6 +110,10 @@ public class EnvironmentConfig {
     String reporterAddress = getProperty(REPORTING_ENDPOINT);
     if (reporterAddress != null) {
       builder.setEndpoint(StringValue.newBuilder().setValue(reporterAddress).build());
+    }
+    String traceReportingType = getProperty(REPORTING_TRACE_TYPE);
+    if (traceReportingType != null) {
+      builder.setTraceReporterType(TraceReporterType.valueOf(traceReportingType));
     }
     String secure = getProperty(REPORTING_SECURE);
     if (secure != null) {

--- a/javaagent-core/src/test/java/org/hypertrace/agent/core/config/EnvironmentConfigTest.java
+++ b/javaagent-core/src/test/java/org/hypertrace/agent/core/config/EnvironmentConfigTest.java
@@ -64,7 +64,8 @@ class EnvironmentConfigTest {
         Arrays.asList(PropagationFormat.B3, PropagationFormat.TRACECONTEXT),
         agentConfig.getPropagationFormatsList());
     Assertions.assertEquals("http://:-)", agentConfig.getReporting().getEndpoint().getValue());
-    Assertions.assertEquals(TraceReporterType.OTLP, agentConfig.getReporting().getTraceReporterType());
+    Assertions.assertEquals(
+        TraceReporterType.OTLP, agentConfig.getReporting().getTraceReporterType());
     Assertions.assertEquals(
         "http://azkaban:9090", agentConfig.getReporting().getOpa().getEndpoint().getValue());
     Assertions.assertEquals(true, agentConfig.getReporting().getOpa().getEnabled().getValue());

--- a/javaagent-core/src/test/java/org/hypertrace/agent/core/config/EnvironmentConfigTest.java
+++ b/javaagent-core/src/test/java/org/hypertrace/agent/core/config/EnvironmentConfigTest.java
@@ -20,6 +20,7 @@ import com.google.protobuf.StringValue;
 import java.util.Arrays;
 import org.hypertrace.agent.config.Config.AgentConfig;
 import org.hypertrace.agent.config.Config.PropagationFormat;
+import org.hypertrace.agent.config.Config.TraceReporterType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.ClearSystemProperty;
@@ -29,6 +30,7 @@ class EnvironmentConfigTest {
   @Test
   @ClearSystemProperty(key = EnvironmentConfig.REPORTING_ENDPOINT)
   @ClearSystemProperty(key = EnvironmentConfig.REPORTING_SECURE)
+  @ClearSystemProperty(key = EnvironmentConfig.REPORTING_TRACE_TYPE)
   @ClearSystemProperty(key = EnvironmentConfig.OPA_ENDPOINT)
   @ClearSystemProperty(key = EnvironmentConfig.OPA_POLL_PERIOD)
   @ClearSystemProperty(key = EnvironmentConfig.OPA_ENABLED)
@@ -41,6 +43,7 @@ class EnvironmentConfigTest {
     // when tests are run in parallel the env vars/sys props set it junit-pioneer are visible to
     // parallel tests
     System.setProperty(EnvironmentConfig.REPORTING_ENDPOINT, "http://:-)");
+    System.setProperty(EnvironmentConfig.REPORTING_TRACE_TYPE, "OTLP");
     System.setProperty(EnvironmentConfig.REPORTING_SECURE, "true");
     System.setProperty(EnvironmentConfig.CAPTURE_HTTP_BODY_PREFIX + "request", "true");
     System.setProperty(EnvironmentConfig.OPA_ENDPOINT, "http://azkaban:9090");
@@ -61,6 +64,7 @@ class EnvironmentConfigTest {
         Arrays.asList(PropagationFormat.B3, PropagationFormat.TRACECONTEXT),
         agentConfig.getPropagationFormatsList());
     Assertions.assertEquals("http://:-)", agentConfig.getReporting().getEndpoint().getValue());
+    Assertions.assertEquals(TraceReporterType.OTLP, agentConfig.getReporting().getTraceReporterType());
     Assertions.assertEquals(
         "http://azkaban:9090", agentConfig.getReporting().getOpa().getEndpoint().getValue());
     Assertions.assertEquals(true, agentConfig.getReporting().getOpa().getEnabled().getValue());

--- a/javaagent-core/src/test/java/org/hypertrace/agent/core/config/HypertraceConfigTest.java
+++ b/javaagent-core/src/test/java/org/hypertrace/agent/core/config/HypertraceConfigTest.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.util.Arrays;
 import org.hypertrace.agent.config.Config.AgentConfig;
 import org.hypertrace.agent.config.Config.PropagationFormat;
+import org.hypertrace.agent.config.Config.TraceReporterType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -38,6 +39,7 @@ public class HypertraceConfigTest {
     AgentConfig agentConfig = HypertraceConfig.load(resource.getPath());
     Assertions.assertTrue(agentConfig.getEnabled().getValue());
     Assertions.assertEquals("unknown", agentConfig.getServiceName().getValue());
+    Assertions.assertEquals(TraceReporterType.ZIPKIN, agentConfig.getReporting().getTraceReporterType());
     Assertions.assertEquals(
         HypertraceConfig.DEFAULT_REPORTING_ENDPOINT,
         agentConfig.getReporting().getEndpoint().getValue());
@@ -100,6 +102,7 @@ public class HypertraceConfigTest {
     Assertions.assertEquals(false, agentConfig.getEnabled().getValue());
     Assertions.assertEquals(
         Arrays.asList(PropagationFormat.B3), agentConfig.getPropagationFormatsList());
+    Assertions.assertEquals(TraceReporterType.OTLP, agentConfig.getReporting().getTraceReporterType());
     Assertions.assertEquals(
         "http://localhost:9411", agentConfig.getReporting().getEndpoint().getValue());
     Assertions.assertEquals(true, agentConfig.getReporting().getSecure().getValue());

--- a/javaagent-core/src/test/java/org/hypertrace/agent/core/config/HypertraceConfigTest.java
+++ b/javaagent-core/src/test/java/org/hypertrace/agent/core/config/HypertraceConfigTest.java
@@ -39,7 +39,8 @@ public class HypertraceConfigTest {
     AgentConfig agentConfig = HypertraceConfig.load(resource.getPath());
     Assertions.assertTrue(agentConfig.getEnabled().getValue());
     Assertions.assertEquals("unknown", agentConfig.getServiceName().getValue());
-    Assertions.assertEquals(TraceReporterType.ZIPKIN, agentConfig.getReporting().getTraceReporterType());
+    Assertions.assertEquals(
+        TraceReporterType.ZIPKIN, agentConfig.getReporting().getTraceReporterType());
     Assertions.assertEquals(
         HypertraceConfig.DEFAULT_REPORTING_ENDPOINT,
         agentConfig.getReporting().getEndpoint().getValue());
@@ -102,7 +103,8 @@ public class HypertraceConfigTest {
     Assertions.assertEquals(false, agentConfig.getEnabled().getValue());
     Assertions.assertEquals(
         Arrays.asList(PropagationFormat.B3), agentConfig.getPropagationFormatsList());
-    Assertions.assertEquals(TraceReporterType.OTLP, agentConfig.getReporting().getTraceReporterType());
+    Assertions.assertEquals(
+        TraceReporterType.OTLP, agentConfig.getReporting().getTraceReporterType());
     Assertions.assertEquals(
         "http://localhost:9411", agentConfig.getReporting().getEndpoint().getValue());
     Assertions.assertEquals(true, agentConfig.getReporting().getSecure().getValue());

--- a/javaagent-core/src/test/resources/config.yaml
+++ b/javaagent-core/src/test/resources/config.yaml
@@ -6,6 +6,7 @@ propagationFormats:
 reporting:
   endpoint: http://localhost:9411
   secure: true
+  trace_reporter_type: otlp
   opa:
     endpoint: http://opa.localhost:8181/
     pollPeriodSeconds: 12

--- a/javaagent-core/src/test/resources/config.yaml
+++ b/javaagent-core/src/test/resources/config.yaml
@@ -6,7 +6,7 @@ propagationFormats:
 reporting:
   endpoint: http://localhost:9411
   secure: true
-  trace_reporter_type: otlp
+  trace_reporter_type: OTLP
   opa:
     endpoint: http://opa.localhost:8181/
     pollPeriodSeconds: 12

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceAgentConfiguration.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceAgentConfiguration.java
@@ -50,7 +50,9 @@ public class HypertraceAgentConfiguration implements PropertySource {
 
     Map<String, String> configProperties = new HashMap<>();
     configProperties.put(OTEL_ENABLED, String.valueOf(agentConfig.getEnabled().getValue()));
-    configProperties.put(OTEL_TRACE_EXPORTER, agentConfig.getReporting().getTraceReporterType().name().toLowerCase());
+    configProperties.put(
+        OTEL_TRACE_EXPORTER,
+        agentConfig.getReporting().getTraceReporterType().name().toLowerCase());
     configProperties.put(
         OTEL_EXPORTER_ZIPKIN_SERVICE_NAME, agentConfig.getServiceName().getValue());
     if (agentConfig.getReporting().getTraceReporterType() == TraceReporterType.ZIPKIN) {

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceAgentConfiguration.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceAgentConfiguration.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.hypertrace.agent.config.Config.AgentConfig;
 import org.hypertrace.agent.config.Config.PropagationFormat;
+import org.hypertrace.agent.config.Config.TraceReporterType;
 import org.hypertrace.agent.core.config.HypertraceConfig;
 
 @AutoService(PropertySource.class)
@@ -49,11 +50,17 @@ public class HypertraceAgentConfiguration implements PropertySource {
 
     Map<String, String> configProperties = new HashMap<>();
     configProperties.put(OTEL_ENABLED, String.valueOf(agentConfig.getEnabled().getValue()));
-    configProperties.put(OTEL_TRACE_EXPORTER, "zipkin");
+    configProperties.put(OTEL_TRACE_EXPORTER, agentConfig.getReporting().getTraceReporterType().name().toLowerCase());
     configProperties.put(
         OTEL_EXPORTER_ZIPKIN_SERVICE_NAME, agentConfig.getServiceName().getValue());
-    configProperties.put(
-        OTEL_EXPORTER_ZIPKIN_ENDPOINT, agentConfig.getReporting().getEndpoint().getValue());
+    if (agentConfig.getReporting().getTraceReporterType() == TraceReporterType.ZIPKIN) {
+      configProperties.put(
+          OTEL_EXPORTER_ZIPKIN_ENDPOINT, agentConfig.getReporting().getEndpoint().getValue());
+    } else if (agentConfig.getReporting().getTraceReporterType() == TraceReporterType.OTLP) {
+      configProperties.put(
+          "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+          agentConfig.getReporting().getEndpoint().getValue());
+    }
     configProperties.put(
         OTEL_PROPAGATORS, toOtelPropagators(agentConfig.getPropagationFormatsList()));
     // metrics are not reported


### PR DESCRIPTION


Tested locally against HT collector 

```
HT_REPORTING_TRACE_REPORTER_TYPE=OTLP HT_REPORTING_ENDPOINT=http://localhost:4317  java -Dio.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel=info  -agentlib:jdwp="transport=dt_socket,server=y,suspend=n,address=5000" -javaagent:${HOME}/projects/hypertrace/javaagent/javaagent/build/libs/hypertrace-agent-0.10.4-SNAPSHOT-all.jar  -jar target/demo-0.0.1-SNAPSHOT.jar
```