### PR TITLE
fix: use the correct otlp endpoint

### DIFF
--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceAgentConfiguration.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceAgentConfiguration.java
@@ -41,6 +41,7 @@ public class HypertraceAgentConfiguration implements PropertySource {
   private static final String OTEL_PROCESSOR_BATCH_MAX_QUEUE = "otel.bsp.max.queue.size";
   private static final String OTEL_DEFAULT_LOG_LEVEL =
       "io.opentelemetry.javaagent.slf4j.simpleLogger.defaultLogLevel";
+  private static final String OTEL_EXPORTER_OTLP_ENDPOINT = "otel.exporter.otlp.endpoint";
 
   private static final String OTEL_ENABLED = "otel.javaagent.enabled";
 
@@ -60,8 +61,7 @@ public class HypertraceAgentConfiguration implements PropertySource {
           OTEL_EXPORTER_ZIPKIN_ENDPOINT, agentConfig.getReporting().getEndpoint().getValue());
     } else if (agentConfig.getReporting().getTraceReporterType() == TraceReporterType.OTLP) {
       configProperties.put(
-          "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-          agentConfig.getReporting().getEndpoint().getValue());
+          OTEL_EXPORTER_OTLP_ENDPOINT, agentConfig.getReporting().getEndpoint().getValue());
     }
     configProperties.put(
         OTEL_PROPAGATORS, toOtelPropagators(agentConfig.getPropagationFormatsList()));


### PR DESCRIPTION
## Description
Based on https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#otlp-exporter-both-span-and-metric-exporters.
Neither OTEL_EXPORTER_OTLP_TRACES_ENDPOINT or otel.exporter.otlp.traces.endpoint work


### Testing
Ran it on a k8s sample application to test for the case where the default `http://localhost:4317` is not set automatically and hence hides the bug.

### Checklist:
- [✅  ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [✅  ] Any dependent changes have been merged and published in downstream modules

