### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "javaagent-core/src/main/proto"]
 	path = javaagent-core/src/main/proto
-	url = git@github.com:hypertrace/agent-config.git
+	url = https://github.com/hypertrace/agent-config.git


### PR DESCRIPTION


## Description
fix for the submodule is configured with an ssh path rather than http. Since this is a public repo authz is not a concern. 


### Testing
I verified locally on a clean repo by using make init-submodules build

### Checklist:
- [ ] My changes generate no new warnings
