### PR TITLE
Move mock filter impl to testing package

### DIFF
--- a/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/SpringBootSmokeTest.java
@@ -20,7 +20,6 @@ import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import okhttp3.Request;

--- a/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/SpringBootSmokeTest.java
@@ -148,20 +148,4 @@ public class SpringBootSmokeTest extends AbstractSmokeTest {
     //    Assertions.assertEquals(1, responseBodyAttributes.size());
     //    Assertions.assertEquals("Hi!", responseBodyAttributes.get(0));
   }
-
-  @Test
-  public void blocking() throws IOException {
-    String url = String.format("http://localhost:%d/greeting", app.getMappedPort(8080));
-    Request request = new Request.Builder().url(url).addHeader("mockblock", "true").get().build();
-    Response response = client.newCall(request).execute();
-    Collection<ExportTraceServiceRequest> traces = waitForTraces();
-
-    Assertions.assertEquals(403, response.code());
-    Assertions.assertEquals(
-        1,
-        getSpanStream(traces)
-            .flatMap(span -> span.getAttributesList().stream())
-            .filter(attribute -> attribute.getKey().equals("hypertrace.mock.filter.result"))
-            .count());
-  }
 }

--- a/testing-common/build.gradle.kts
+++ b/testing-common/build.gradle.kts
@@ -31,5 +31,6 @@ dependencies {
     testFixturesImplementation("net.bytebuddy:byte-buddy:${versions["byte_buddy"]}")
     testFixturesImplementation("net.bytebuddy:byte-buddy-agent:${versions["byte_buddy"]}")
     testFixturesCompileOnly("com.google.auto.service:auto-service-annotations:1.0")
+    testFixturesAnnotationProcessor("com.google.auto.service:auto-service:1.0")
     testFixturesImplementation("org.eclipse.jetty:jetty-server:8.0.0.v20110901")
 }

--- a/testing-common/src/testFixtures/java/org/hypertrace/agent/testing/mockfilter/MockFilter.java
+++ b/testing-common/src/testFixtures/java/org/hypertrace/agent/testing/mockfilter/MockFilter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.hypertrace.agent.filter.mock;
+package org.hypertrace.agent.testing.mockfilter;
 
 import io.opentelemetry.api.trace.Span;
 import java.util.Map;

--- a/testing-common/src/testFixtures/java/org/hypertrace/agent/testing/mockfilter/MockFilterProvider.java
+++ b/testing-common/src/testFixtures/java/org/hypertrace/agent/testing/mockfilter/MockFilterProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.hypertrace.agent.filter.mock;
+package org.hypertrace.agent.testing.mockfilter;
 
 import com.google.auto.service.AutoService;
 import org.hypertrace.agent.filter.api.Filter;


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

## Description

Before this PR the mock filter implementation was packaged in the agent distribution. The mock filter shouldn't be exposed in the final distribution. Its only purpose is to test blocking in instrumentations which is done by moving the filter into the testing package.  