### PR TITLE
Remove dependency on weak map

### DIFF
--- a/javaagent-core/build.gradle.kts
+++ b/javaagent-core/build.gradle.kts
@@ -10,7 +10,4 @@ dependencies {
     api("io.opentelemetry.javaagent:opentelemetry-javaagent-api:${versions["opentelemetry_java_agent"]}")
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-caching:${versions["opentelemetry_java_agent"]}")
     implementation("org.slf4j:slf4j-api:${versions["slf4j"]}")
-
-    // TODO (pavolloffay) remove
-    implementation("com.blogspot.mydailyjava:weak-lock-free:0.17")
 }

--- a/javaagent-tooling/build.gradle.kts
+++ b/javaagent-tooling/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap:${versions["opentelemetry_java_agent"]}")
     instrumentationMuzzle("net.bytebuddy:byte-buddy:1.10.18")
     instrumentationMuzzle("net.bytebuddy:byte-buddy-agent:1.10.18")
-    instrumentationMuzzle("com.blogspot.mydailyjava:weak-lock-free:0.15")
     instrumentationMuzzle("com.google.auto.service:auto-service:1.0")
     instrumentationMuzzle("org.slf4j:slf4j-api:${versions["slf4j"]}")
 }


### PR DESCRIPTION
Not needed anymore, it's not used directly. The relocation is there in case it gets used (it is still 3rd party dependency in OTEL agent). 