### PR TITLE
Ignore appdynamics/cisco multi tenant agent module

### DIFF
--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceGlobalIgnoreMatcher.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/HypertraceGlobalIgnoreMatcher.java
@@ -52,7 +52,9 @@ public class HypertraceGlobalIgnoreMatcher implements IgnoreMatcherProvider {
     }
 
     String name = classLoader.getClass().getName();
-    if (name.startsWith("com.singularity.") || name.startsWith("com.yourkit.")) {
+    if (name.startsWith("com.singularity.")
+        || name.startsWith("com.yourkit.")
+        || name.startsWith("com.cisco.mtagent.")) {
       return Result.IGNORE;
     }
     return Result.DEFAULT;


### PR DESCRIPTION
## Description

When running the Hypertrace Javaagent with the Appdynamics javaagent on 9+ JVM, the following error occurs after ~3 minutes of leaving an app server running with no HTTP traffic 

```bash
[Cisco-Multi-Tenant-Agent-Bootstrapping] ERROR io.opentelemetry.javaagent.tooling.HelperInjector - Error preparing helpers while processing class okhttp3.OkHttpClient for okhttp. Failed to inject helper classes into instance MultiTenantAgentClassLoader
java.lang.IllegalStateException: Error invoking (accessor)::defineClass
	at net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection$Dispatcher$UsingUnsafeInjection.defineClass(ClassInjector.java:999)
	at net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection.injectRaw(ClassInjector.java:251)
	at io.opentelemetry.javaagent.tooling.HelperInjector.injectClassLoader(HelperInjector.java:205)
	at io.opentelemetry.javaagent.tooling.HelperInjector.transform(HelperInjector.java:137)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.doTransform(AgentBuilder.java:10364)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10302)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.access$1600(AgentBuilder.java:10068)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$Java9CapableVmDispatcher.run(AgentBuilder.java:10761)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$Java9CapableVmDispatcher.run(AgentBuilder.java:10699)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer.transform(AgentBuilder.java:10258)
	at net.bytebuddy.agent.builder.AgentBuilder$Default$ExecutingTransformer$ByteBuddy$ModuleSupport.transform(Unknown Source)
	at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)
	at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:563)
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:550)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:458)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:452)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:451)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3166)
	at java.base/java.lang.Class.getDeclaredMethods(Class.java:2309)
	at MultiTenantAgentClassLoader/org.picocontainer.injectors.AdaptingInjection$1.run(AdaptingInjection.java:203)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at MultiTenantAgentClassLoader/org.picocontainer.injectors.AdaptingInjection.injectionMethodAnnotated(AdaptingInjection.java:200)
	at MultiTenantAgentClassLoader/org.picocontainer.injectors.AdaptingInjection.methodAnnotatedInjectionAdapter(AdaptingInjection.java:171)
	at MultiTenantAgentClassLoader/org.picocontainer.injectors.AdaptingInjection.createComponentAdapter(AdaptingInjection.java:70)
	at MultiTenantAgentClassLoader/org.picocontainer.behaviors.AbstractBehaviorFactory.createComponentAdapter(AbstractBehaviorFactory.java:44)
	at MultiTenantAgentClassLoader/org.picocontainer.behaviors.Caching.createComponentAdapter(Caching.java:46)
	at MultiTenantAgentClassLoader/org.picocontainer.behaviors.AdaptingBehavior.createComponentAdapter(AdaptingBehavior.java:58)
	at MultiTenantAgentClassLoader/org.picocontainer.DefaultPicoContainer.addComponent(DefaultPicoContainer.java:536)
	at MultiTenantAgentClassLoader/org.picocontainer.DefaultPicoContainer.addComponent(DefaultPicoContainer.java:501)
	at MultiTenantAgentClassLoader/org.picocontainer.DefaultPicoContainer.access$400(DefaultPicoContainer.java:84)
	at MultiTenantAgentClassLoader/org.picocontainer.DefaultPicoContainer$AsPropertiesPicoContainer.addComponent(DefaultPicoContainer.java:1157)
	at MultiTenantAgentClassLoader/com.cisco.mtagent.core.AgentPicoContainer.createSingleton(AgentPicoContainer.java:135)
	at MultiTenantAgentClassLoader/com.cisco.mtagent.core.AgentPicoContainer.initializeMultiTenantAgent(AgentPicoContainer.java:108)
	at MultiTenantAgentClassLoader/com.cisco.mtagent.core.AgentPicoContainer.bootstrapMultiAgentInstances(AgentPicoContainer.java:71)
	at MultiTenantAgentClassLoader/com.cisco.mtagent.core.AgentPicoContainer.bootstrapMultiTenantAgent(AgentPicoContainer.java:58)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.cisco.mtagent.entry.MTAgent$2.run(MTAgent.java:324)
Caused by: java.lang.IllegalAccessError: superinterface check failed: class io.opentelemetry.javaagent.instrumentation.okhttp.v3_0.TracingInterceptor (in unnamed module @0x7aeb0422) cannot access class okhttp3.Interceptor (in module MultiTenantAgentClassLoader) because module MultiTenantAgentClassLoader does not export okhttp3 to unnamed module @0x7aeb0422
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
	at java.base/java.lang.ClassLoader$ByteBuddyAccessor$GCVZL2mm.defineClass(Unknown Source)
	at java.base/jdk.internal.reflect.GeneratedMethodAccessor44.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection$Dispatcher$UsingUnsafeInjection.defineClass(ClassInjector.java:995)
	... 47 more
```


### Testing
I verified this locally using Tomcat 9 on Correto 11 with Hypertrace and Appdynamics installed. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (N/A, we don't have a good way to test other agenets)
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
