### PR TITLE
✨ Expose reporting config to consumers of `javaagent-core` so that `Filter` implementation authors can access them

### DIFF
--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/config/InstrumentationConfig.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/config/InstrumentationConfig.java
@@ -41,7 +41,6 @@ public interface InstrumentationConfig {
 
   /** Message holds data capture configuration for various entities. */
   interface Message {
-
     boolean request();
 
     boolean response();

--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/config/InstrumentationConfig.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/config/InstrumentationConfig.java
@@ -39,47 +39,12 @@ public interface InstrumentationConfig {
   /** Data capture for RPC body */
   Message rpcBody();
 
-  Reporting reporting();
-
   /** Message holds data capture configuration for various entities. */
   interface Message {
 
     boolean request();
 
     boolean response();
-  }
-
-  interface Reporting {
-
-    /**
-     * @return the {@link Opa} config implementation
-     * @see Opa for more information on why this API is deprecated
-     */
-    @Deprecated
-    Opa opa();
-
-    boolean secure();
-
-    String token();
-  }
-
-  /**
-   * Opa holds the configuration for the agent and filter implementations should interact with a
-   * remote Open Policy Agent endpoint.
-   *
-   * <p>Note, this API is deprecated because it is a goal of the Hypertrace community to migrate
-   * away form supplying this vendor-specific config and instead have authors of Hypertrace
-   * extensions/filters to have an indiomatic way to extned the Hypertrace configuration properties
-   * for their use cases
-   */
-  @Deprecated
-  interface Opa {
-
-    boolean enabled();
-
-    String endpoint();
-
-    int pollPeriodSeconds();
   }
 
   default boolean isInstrumentationEnabled(String primaryName, String[] otherNames) {

--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/config/InstrumentationConfig.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/config/InstrumentationConfig.java
@@ -39,11 +39,47 @@ public interface InstrumentationConfig {
   /** Data capture for RPC body */
   Message rpcBody();
 
+  Reporting reporting();
+
   /** Message holds data capture configuration for various entities. */
   interface Message {
+
     boolean request();
 
     boolean response();
+  }
+
+  interface Reporting {
+
+    /**
+     * @return the {@link Opa} config implementation
+     * @see Opa for more information on why this API is deprecated
+     */
+    @Deprecated
+    Opa opa();
+
+    boolean secure();
+
+    String token();
+  }
+
+  /**
+   * Opa holds the configuration for the agent and filter implementations should interact with a
+   * remote Open Policy Agent endpoint.
+   *
+   * <p>Note, this API is deprecated because it is a goal of the Hypertrace community to migrate
+   * away form supplying this vendor-specific config and instead have authors of Hypertrace
+   * extensions/filters to have an indiomatic way to extned the Hypertrace configuration properties
+   * for their use cases
+   */
+  @Deprecated
+  interface Opa {
+
+    boolean enabled();
+
+    String endpoint();
+
+    int pollPeriodSeconds();
   }
 
   default boolean isInstrumentationEnabled(String primaryName, String[] otherNames) {

--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/config/ReportingConfig.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/config/ReportingConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.core.config;
+
+public interface ReportingConfig {
+
+  /**
+   * @return the {@link Opa} config implementation
+   * @see Opa for more information on why this API is deprecated
+   */
+  @Deprecated
+  Opa opa();
+
+  boolean secure();
+
+  String token();
+
+  /**
+   * Opa holds the configuration for the agent and filter implementations should interact with a
+   * remote Open Policy Agent endpoint.
+   *
+   * <p>Note, this API is deprecated because it is a goal of the Hypertrace community to migrate
+   * away form supplying this vendor-specific config and instead have authors of Hypertrace
+   * extensions/filters to have an indiomatic way to extned the Hypertrace configuration properties
+   * for their use cases
+   */
+  @Deprecated
+  interface Opa {
+
+    boolean enabled();
+
+    String endpoint();
+
+    int pollPeriodSeconds();
+  }
+}

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/InstrumentationConfigImpl.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/InstrumentationConfigImpl.java
@@ -21,8 +21,6 @@ import org.hypertrace.agent.config.Config;
 import org.hypertrace.agent.config.Config.AgentConfig;
 import org.hypertrace.agent.config.Config.DataCapture;
 import org.hypertrace.agent.config.Config.Message;
-import org.hypertrace.agent.config.Config.Opa;
-import org.hypertrace.agent.config.Config.Reporting;
 import org.hypertrace.agent.core.config.InstrumentationConfig;
 
 @AutoService(InstrumentationConfig.class)
@@ -34,7 +32,6 @@ public class InstrumentationConfigImpl implements InstrumentationConfig {
   private final Message httpBody;
   private final Message rpcMetadata;
   private final Message rpcBody;
-  private final Reporting reporting;
 
   public InstrumentationConfigImpl() {
     DataCapture dataCapture = agentConfig.getDataCapture();
@@ -42,7 +39,6 @@ public class InstrumentationConfigImpl implements InstrumentationConfig {
     this.httpBody = new MessageImpl(dataCapture.getHttpBody());
     this.rpcMetadata = new MessageImpl(dataCapture.getRpcMetadata());
     this.rpcBody = new MessageImpl(dataCapture.getRpcBody());
-    reporting = new ReportingImpl(agentConfig.getReporting());
   }
 
   @Override
@@ -70,11 +66,6 @@ public class InstrumentationConfigImpl implements InstrumentationConfig {
     return this.rpcBody;
   }
 
-  @Override
-  public Reporting reporting() {
-    return reporting;
-  }
-
   private static final class MessageImpl implements Message {
 
     private final Config.Message message;
@@ -91,56 +82,6 @@ public class InstrumentationConfigImpl implements InstrumentationConfig {
     @Override
     public boolean response() {
       return message.getResponse().getValue();
-    }
-  }
-
-  private static final class ReportingImpl implements Reporting {
-
-    private final Opa opa;
-    private final Config.Reporting reporting;
-
-    public ReportingImpl(final Config.Reporting reporting) {
-      opa = new OpaImpl(reporting.getOpa());
-      this.reporting = reporting;
-    }
-
-    @Override
-    public Opa opa() {
-      return opa;
-    }
-
-    @Override
-    public boolean secure() {
-      return reporting.getSecure().getValue();
-    }
-
-    @Override
-    public String token() {
-      return reporting.getToken().getValue();
-    }
-  }
-
-  private static final class OpaImpl implements Opa {
-
-    private final Config.Opa opa;
-
-    public OpaImpl(final Config.Opa opa) {
-      this.opa = opa;
-    }
-
-    @Override
-    public boolean enabled() {
-      return opa.getEnabled().getValue();
-    }
-
-    @Override
-    public String endpoint() {
-      return opa.getEndpoint().getValue();
-    }
-
-    @Override
-    public int pollPeriodSeconds() {
-      return opa.getPollPeriodSeconds().getValue();
     }
   }
 }

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/InstrumentationConfigImpl.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/InstrumentationConfigImpl.java
@@ -20,6 +20,9 @@ import com.google.auto.service.AutoService;
 import org.hypertrace.agent.config.Config;
 import org.hypertrace.agent.config.Config.AgentConfig;
 import org.hypertrace.agent.config.Config.DataCapture;
+import org.hypertrace.agent.config.Config.Message;
+import org.hypertrace.agent.config.Config.Opa;
+import org.hypertrace.agent.config.Config.Reporting;
 import org.hypertrace.agent.core.config.InstrumentationConfig;
 
 @AutoService(InstrumentationConfig.class)
@@ -31,6 +34,7 @@ public class InstrumentationConfigImpl implements InstrumentationConfig {
   private final Message httpBody;
   private final Message rpcMetadata;
   private final Message rpcBody;
+  private final Reporting reporting;
 
   public InstrumentationConfigImpl() {
     DataCapture dataCapture = agentConfig.getDataCapture();
@@ -38,6 +42,7 @@ public class InstrumentationConfigImpl implements InstrumentationConfig {
     this.httpBody = new MessageImpl(dataCapture.getHttpBody());
     this.rpcMetadata = new MessageImpl(dataCapture.getRpcMetadata());
     this.rpcBody = new MessageImpl(dataCapture.getRpcBody());
+    reporting = new ReportingImpl(agentConfig.getReporting());
   }
 
   @Override
@@ -65,6 +70,11 @@ public class InstrumentationConfigImpl implements InstrumentationConfig {
     return this.rpcBody;
   }
 
+  @Override
+  public Reporting reporting() {
+    return reporting;
+  }
+
   private class MessageImpl implements Message {
 
     private final Config.Message message;
@@ -81,6 +91,56 @@ public class InstrumentationConfigImpl implements InstrumentationConfig {
     @Override
     public boolean response() {
       return message.getResponse().getValue();
+    }
+  }
+
+  private static final class ReportingImpl implements Reporting {
+
+    private final Opa opa;
+    private final Config.Reporting reporting;
+
+    public ReportingImpl(final Config.Reporting reporting) {
+      opa = new OpaImpl(reporting.getOpa());
+      this.reporting = reporting;
+    }
+
+    @Override
+    public Opa opa() {
+      return opa;
+    }
+
+    @Override
+    public boolean secure() {
+      return reporting.getSecure().getValue();
+    }
+
+    @Override
+    public String token() {
+      return reporting.getToken().getValue();
+    }
+  }
+
+  private static final class OpaImpl implements Opa {
+
+    private final Config.Opa opa;
+
+    public OpaImpl(final Config.Opa opa) {
+      this.opa = opa;
+    }
+
+    @Override
+    public boolean enabled() {
+      return opa.getEnabled().getValue();
+    }
+
+    @Override
+    public String endpoint() {
+      return opa.getEndpoint().getValue();
+    }
+
+    @Override
+    public int pollPeriodSeconds() {
+      return opa.getPollPeriodSeconds().getValue();
     }
   }
 }

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/InstrumentationConfigImpl.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/InstrumentationConfigImpl.java
@@ -75,7 +75,7 @@ public class InstrumentationConfigImpl implements InstrumentationConfig {
     return reporting;
   }
 
-  private class MessageImpl implements Message {
+  private static final class MessageImpl implements Message {
 
     private final Config.Message message;
 

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/ReportingConfigImpl.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/ReportingConfigImpl.java
@@ -56,7 +56,7 @@ public final class ReportingConfigImpl implements ReportingConfig {
 
     @Override
     public boolean enabled() {
-      return opa.getEnabled().getValue();
+      return opa.hasEnabled() ? opa.getEnabled().getValue() : true;
     }
 
     @Override

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/ReportingConfigImpl.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/ReportingConfigImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.otel.extensions.config;
+
+import com.google.auto.service.AutoService;
+import org.hypertrace.agent.config.Config;
+import org.hypertrace.agent.core.config.ReportingConfig;
+
+@AutoService(ReportingConfig.class)
+public final class ReportingConfigImpl implements ReportingConfig {
+
+  private final Opa opa;
+  private final Config.Reporting reporting;
+
+  public ReportingConfigImpl(final Config.Reporting reporting) {
+    opa = new OpaImpl(reporting.getOpa());
+    this.reporting = reporting;
+  }
+
+  @Override
+  public Opa opa() {
+    return opa;
+  }
+
+  @Override
+  public boolean secure() {
+    return reporting.getSecure().getValue();
+  }
+
+  @Override
+  public String token() {
+    return reporting.getToken().getValue();
+  }
+
+  private static final class OpaImpl implements Opa {
+
+    private final Config.Opa opa;
+
+    public OpaImpl(final Config.Opa opa) {
+      this.opa = opa;
+    }
+
+    @Override
+    public boolean enabled() {
+      return opa.getEnabled().getValue();
+    }
+
+    @Override
+    public String endpoint() {
+      return opa.getEndpoint().getValue();
+    }
+
+    @Override
+    public int pollPeriodSeconds() {
+      return opa.getPollPeriodSeconds().getValue();
+    }
+  }
+}

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/ReportingConfigImpl.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/ReportingConfigImpl.java
@@ -27,7 +27,7 @@ public final class ReportingConfigImpl implements ReportingConfig {
   private final Config.Reporting reporting;
 
   public ReportingConfigImpl(final Config.Reporting reporting) {
-    opa = new OpaImpl(reporting.getOpa());
+    this.opa = new OpaImpl(reporting.getOpa());
     this.reporting = reporting;
   }
 


### PR DESCRIPTION
## Description
Allow the HypertraceConfig APIs around reporting and OPA configuration to be exposed to clients following a similar pattern as done with the `InstrumentationConfig`.  PR #322 moved the config implementation out of the `javaagent-core` package, but some implementations of the Hypertrace Filter API need to access config properties that are not accessible via the `InstrumentationConfig` object. As this is a public API, I wanted to make it well known that the `ReportingConfig.Opa` object isn't going to live forever in this repo, as we'd like to eventually remove configuraton options that are intended for use by Traceable to not be included in the Hypertrace repo. 

### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

N/A
<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
