### PR TITLE
🐛 Report config service loader fix

### DIFF
--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/ReportingConfigImpl.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/ReportingConfigImpl.java
@@ -26,9 +26,18 @@ public final class ReportingConfigImpl implements ReportingConfig {
   private final Opa opa;
   private final Config.Reporting reporting;
 
-  public ReportingConfigImpl(final Config.Reporting reporting) {
-    this.opa = new OpaImpl(reporting.getOpa());
-    this.reporting = reporting;
+  /**
+   * This constructor is required in order to be instantiated by the {@link java.util.ServiceLoader}
+   * API.
+   */
+  @SuppressWarnings("unused")
+  public ReportingConfigImpl() {
+    this(HypertraceConfig.get().getReporting());
+  }
+
+  public ReportingConfigImpl(final Config.Reporting reportingConfig) {
+    this.reporting = reportingConfig;
+    this.opa = new OpaImpl(reportingConfig.getOpa());
   }
 
   @Override

--- a/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/ReportingConfigImplTest.java
+++ b/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/ReportingConfigImplTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.otel.extensions.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.protobuf.BoolValue;
+import java.util.Iterator;
+import java.util.ServiceLoader;
+import org.hypertrace.agent.config.Config.Opa;
+import org.hypertrace.agent.config.Config.Reporting;
+import org.hypertrace.agent.config.Config.Reporting.Builder;
+import org.hypertrace.agent.core.config.ReportingConfig;
+import org.junit.jupiter.api.Test;
+
+final class ReportingConfigImplTest {
+
+  @Test
+  void instantiateViaServiceLoaderApi() {
+    final ServiceLoader<ReportingConfig> reportingConfigs =
+        ServiceLoader.load(ReportingConfig.class);
+    final Iterator<ReportingConfig> iterator = reportingConfigs.iterator();
+    assertTrue(iterator.hasNext());
+    final ReportingConfig reportingConfig = iterator.next();
+    assertNotNull(reportingConfig);
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  void opaEnabledIfNotProvided() {
+    final ReportingConfigImpl reportingConfig =
+        new ReportingConfigImpl(Reporting.getDefaultInstance());
+    assertTrue(reportingConfig.opa().enabled());
+  }
+
+  @Test
+  void opaDisabledIfExplicitlySet() {
+    final Builder reportingBuilder = Reporting.getDefaultInstance().toBuilder();
+    final Opa explicitOpaConfig =
+        reportingBuilder.getOpaBuilder().setEnabled(BoolValue.of(false)).build();
+    final ReportingConfigImpl reportingConfig =
+        new ReportingConfigImpl(reportingBuilder.setOpa(explicitOpaConfig).build());
+    assertFalse(reportingConfig.opa().enabled());
+  }
+}


### PR DESCRIPTION
## Description
Fixes a bug where the ReportingConfigImpl could not be instantiated by the service loader API


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
