### PR TITLE
Set Java 8 release compiler option

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ allprojects {
     tasks.withType<JavaCompile> {
         options.compilerArgs.add("-Xlint:unchecked")
         options.isDeprecation = true
+        options.release.set(8)
     }
 }
 


### PR DESCRIPTION
# Use --release flag to target JDK 8 bytecode compatibility
My recent change to capture HTTP requests contained a fascinating bug resulting in the bug-fix not working when running on JVMs <= 1.8 due to a `NoSuchMethodError` being thrown when [this line](https://github.com/hypertrace/javaagent/blob/main/instrumentation/undertow/undertow-1.4/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/undertow/v1_4/utils/Utils.java#L89) executes.  This was incredibly surprising to me, because the `position(int)` API exists on `Buffer` (the superclass of `ByteBuffer` ) in java 1.8, so why do we have problems here? Confused, I did a quick google search and found an incredibly helpful article right away: [ByteBuffer and the Dreaded NoSuchMethodError](https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/). The tl;dr of this change is that, the bytecode we produce prior to this change  looked like this:

### BEFORE
```java
  public static void handleRead(java.nio.ByteBuffer, int, org.hypertrace.agent.core.instrumentation.SpanAndBuffer);
    descriptor: (Ljava/nio/ByteBuffer;ILorg/hypertrace/agent/core/instrumentation/SpanAndBuffer;)V
    flags: (0x0009) ACC_PUBLIC, ACC_STATIC
    Code:
      stack=3, locals=6, args_size=3
         0: iload_1
         1: ifgt          5
         4: return
         5: aload_0
         6: aload_0
         7: invokevirtual #23                 // Method java/nio/ByteBuffer.position:()I
        10: iload_1
        11: isub
        12: invokevirtual #24                 // Method java/nio/ByteBuffer.position:(I)Ljava/nio/ByteBuffer;
```

### AFTER
```java
 public static void handleRead(java.nio.ByteBuffer, int, org.hypertrace.agent.core.instrumentation.SpanAndBuffer);
    descriptor: (Ljava/nio/ByteBuffer;ILorg/hypertrace/agent/core/instrumentation/SpanAndBuffer;)V
    flags: (0x0009) ACC_PUBLIC, ACC_STATIC
    Code:
      stack=3, locals=6, args_size=3
         0: iload_1
         1: ifgt          5
         4: return
         5: aload_0
         6: aload_0
         7: invokevirtual #23                 // Method java/nio/ByteBuffer.position:()I
        10: iload_1
        11: isub
        12: invokevirtual #24                 // Method java/nio/ByteBuffer.position:(I)Ljava/nio/Buffer;
```

Spot the difference? The bytecode for this snippet is identical, but when compiled without the `--release 8`, the `invokevirtual #24` call refers to a method reference in the constant pool with a signature matching the descriptor `Method java/nio/ByteBuffer.position:(I)Ljava/nio/ByteBuffer`. However, when we compile it with the `--release 8` flag the method reference in the constant pool is `Method java/nio/ByteBuffer.position:(I)Ljava/nio/Buffer`. This resolves the cross-jre compatibility issue of using the `ByteBuffer.position(int)` API because  `Method java/nio/ByteBuffer.position:(I)Ljava/nio/ByteBuffer` does not exist on JDK 1.8 or below. 


## Other notes
It's worth noting that this has impacted many well-known open source projects. The blog i linked above links to several other projects that encountered this exact issue:
- Eclipse Jetty
- Apache Pulsar
- Eclipse Vert.x
- Apache Thrift
- the Yugabyte DB client
- Debezium (the project the author found the bug on)

The author also evaluated other methods of resolving this issue and verifying that it couldn't happen again, and determined the `--release` flag was the best option:
> Note that theoretically you could achieve the same effect also when using --source and --target; by means of the --boot-class-path option, you could advise the compiler to use a specific set of bootstrap class files instead of those from the JDK used for compilation. But that’d be quite a bit more cumbersome as it requires you to actually provide the classes of the targeted Java version, whereas --release will make use of the signature data coming with the currently used JDK itself.