### PR TITLE
🐛  fix bug where release pipeline is triggered on every branch creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: release
 on:
-  create:
-    tags: ['^[0-9]+\.[0-9]+\.[0-9]+']
+  push:
+    tags: ['[0-9]+\.[0-9]+\.[0-9]+']
 
 jobs:
   test:


### PR DESCRIPTION
## Description
Currently, when a new branch is created, a release pipeline is triggered. i believe that is because the syntax of the GitHub actions workflow for our release pipeline needs to be tweaked to use the YAML path `on.push.tags` rather than `on.create.tags`. 

See:
- https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags
- https://github.community/t/how-to-run-github-actions-workflow-only-for-new-tags/16075/18
