### PR TITLE
✨ Default to OTLP exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The final artifact is in `javaagent/build/libs/hypertrace-agent-<version>-all.ja
 Download the [latest version](https://github.com/hypertrace/javaagent/releases/latest/download/hypertrace-agent-all.jar).
 
 ```bash
-HT_EXPORTING_ENDPOINT=http://localhost:9411/api/v2/spans java -javaagent:javaagent/build/libs/hypertrace-agent-<version>-all.jar -jar app.jar
+HT_REPORTING_ENDPOINT=http://localhost:4317 java -javaagent:javaagent/build/libs/hypertrace-agent-<version>-all.jar -jar app.jar
 ```
 
 By default the agent uses Zipkin exporter.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Download the [latest version](https://github.com/hypertrace/javaagent/releases/l
 HT_REPORTING_ENDPOINT=http://localhost:4317 java -javaagent:javaagent/build/libs/hypertrace-agent-<version>-all.jar -jar app.jar
 ```
 
-By default the agent uses Zipkin exporter.
+By default the agent uses Otlp exporter.
 
 The configuration precedence order 
 1. OpenTelemetry Agent's trace config file `OTEL_TRACE_CONFIG`/`otel.trace.config`

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,3 +1,3 @@
 service_name: service_name
 reporting:
-  endpoint: http://localhost:9411/api/v2/spans
+  endpoint: http://localhost:4317

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfig.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfig.java
@@ -38,6 +38,7 @@ import org.hypertrace.agent.config.Config.Opa;
 import org.hypertrace.agent.config.Config.Opa.Builder;
 import org.hypertrace.agent.config.Config.PropagationFormat;
 import org.hypertrace.agent.config.Config.Reporting;
+import org.hypertrace.agent.config.Config.TraceReporterType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,7 @@ public class HypertraceConfig {
   private static volatile AgentConfig agentConfig;
 
   static final String DEFAULT_SERVICE_NAME = "unknown";
-  static final String DEFAULT_REPORTING_ENDPOINT = "http://localhost:9411/api/v2/spans";
+  static final String DEFAULT_REPORTING_ENDPOINT = "http://localhost:4317";
   static final String DEFAULT_OPA_ENDPOINT = "http://opa.traceableai:8181/";
   static final int DEFAULT_OPA_POLL_PERIOD_SECONDS = 30;
   // 128 KiB
@@ -143,7 +144,7 @@ public class HypertraceConfig {
       builder.setEndpoint(StringValue.newBuilder().setValue(DEFAULT_REPORTING_ENDPOINT).build());
     }
     if (builder.getTraceReporterType().equals(Config.TraceReporterType.UNSPECIFIED)) {
-      builder.setTraceReporterType(Config.TraceReporterType.ZIPKIN);
+      builder.setTraceReporterType(TraceReporterType.OTLP);
     }
     Builder opaBuilder = applyOpaDefaults(builder.getOpa().toBuilder());
     builder.setOpa(opaBuilder);

--- a/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
+++ b/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
@@ -40,7 +40,7 @@ public class HypertraceConfigTest {
     Assertions.assertTrue(agentConfig.getEnabled().getValue());
     Assertions.assertEquals("unknown", agentConfig.getServiceName().getValue());
     Assertions.assertEquals(
-        TraceReporterType.ZIPKIN, agentConfig.getReporting().getTraceReporterType());
+        TraceReporterType.OTLP, agentConfig.getReporting().getTraceReporterType());
     Assertions.assertEquals(
         HypertraceConfig.DEFAULT_REPORTING_ENDPOINT,
         agentConfig.getReporting().getEndpoint().getValue());

--- a/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
+++ b/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
@@ -106,7 +106,7 @@ public class HypertraceConfigTest {
     Assertions.assertEquals(
         TraceReporterType.OTLP, agentConfig.getReporting().getTraceReporterType());
     Assertions.assertEquals(
-        "http://localhost:9411", agentConfig.getReporting().getEndpoint().getValue());
+        "http://localhost:4317", agentConfig.getReporting().getEndpoint().getValue());
     Assertions.assertEquals(true, agentConfig.getReporting().getSecure().getValue());
     Assertions.assertEquals(
         "http://opa.localhost:8181/", agentConfig.getReporting().getOpa().getEndpoint().getValue());

--- a/otel-extensions/src/test/resources/config.yaml
+++ b/otel-extensions/src/test/resources/config.yaml
@@ -4,7 +4,7 @@ enabled: false
 propagationFormats:
   - B3
 reporting:
-  endpoint: http://localhost:9411
+  endpoint: http://localhost:4317
   secure: true
   trace_reporter_type: OTLP
   opa:

--- a/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/AbstractSmokeTest.java
+++ b/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/AbstractSmokeTest.java
@@ -49,6 +49,7 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 public abstract class AbstractSmokeTest {
+
   private static final Logger log = LoggerFactory.getLogger(OpenTelemetryStorage.class);
   private static final String OTEL_COLLECTOR_IMAGE = "otel/opentelemetry-collector:0.21.0";
   private static final String MOCK_BACKEND_IMAGE =
@@ -157,6 +158,13 @@ public abstract class AbstractSmokeTest {
     return traceRequest.stream()
         .flatMap(request -> request.getResourceSpansList().stream())
         .flatMap(resourceSpans -> resourceSpans.getInstrumentationLibrarySpansList().stream());
+  }
+
+  protected Collection<ExportTraceServiceRequest> waitForTraces(final int count) {
+    return Awaitility.await()
+        .until(
+            this::waitForTraces,
+            exportTraceServiceRequests -> exportTraceServiceRequests.size() == count);
   }
 
   protected Collection<ExportTraceServiceRequest> waitForTraces() throws IOException {

--- a/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/SpringBootSmokeTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -185,7 +186,8 @@ public class SpringBootSmokeTest extends AbstractSmokeTest {
     try (Response response = client.newCall(request).execute()) {
       Assertions.assertEquals(response.body().string(), requestBody);
     }
-    ArrayList<ExportTraceServiceRequest> traces = new ArrayList<>(waitForTraces());
+
+    Collection<ExportTraceServiceRequest> traces = waitForTraces(2);
 
     List<String> responseBodyAttributes =
         getSpanStream(traces)


### PR DESCRIPTION
## Description
Change the default exporter, and update the associated configs/tests/markdowns in this repo to indicate that

### Testing
Existing testing seems sufficient. Our smoke tests had previously been updated to use the OTLP exporter.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.


