### PR TITLE
🐛 fix bug where build/smoke test checkout action usage checks out head of main branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2.3.4
         with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
           submodules: true
 
@@ -45,6 +47,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2.3.4
         with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
           submodules: true
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2.3.4
         with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
           submodules: true
 


### PR DESCRIPTION
## Description
For some reason, actions that use the `pull_request_target` attribute causes the deefault checkout destination of the checkout action to be whatever is currently the head of `origin/main`. This can allow build/test errors from PRs make it into the main branch before failing (but not allowing them to be released). An example PR is #337. Note, the GHA all passed on commit [e9d665c](https://github.com/hypertrace/javaagent/pull/337/commits/e9d665c14fea8040093a440247d8709bfb2e94f8). However, note the checkout action step for that PR [here](https://github.com/hypertrace/javaagent/runs/3069158994#step:2:547). It checks out the commit from what was currently the head of `origin/main` (ref `4a920915c55e3d0e86806482bec736554315100b`) and caused the PR to pass all builds, only to have the main build fail once the PR was merged. This resulted in us needing to quickly patch in PR #338. 


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
