### PR TITLE
🐛 Fix spring boot smoke test taking a long time, set more sensible default for OPA endpoint 

### DIFF
--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfig.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfig.java
@@ -54,7 +54,7 @@ public class HypertraceConfig {
 
   static final String DEFAULT_SERVICE_NAME = "unknown";
   static final String DEFAULT_REPORTING_ENDPOINT = "http://localhost:4317";
-  static final String DEFAULT_OPA_ENDPOINT = "http://opa.traceableai:8181/";
+  static final String DEFAULT_OPA_ENDPOINT = "http://localhost:8181/";
   static final int DEFAULT_OPA_POLL_PERIOD_SECONDS = 30;
   // 128 KiB
   static final int DEFAULT_BODY_MAX_SIZE_BYTES = 128 * 1024;

--- a/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/AbstractSmokeTest.java
+++ b/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/AbstractSmokeTest.java
@@ -22,6 +22,7 @@ import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans;
 import io.opentelemetry.proto.trace.v1.Span;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -162,6 +163,7 @@ public abstract class AbstractSmokeTest {
 
   protected Collection<ExportTraceServiceRequest> waitForTraces(final int count) {
     return Awaitility.await()
+        .atMost(Duration.ofSeconds(10))
         .until(
             this::waitForTraces,
             exportTraceServiceRequests -> exportTraceServiceRequests.size() == count);


### PR DESCRIPTION
## Description
The spring boot smoke test was sometimes timing out and the pipeline would run for a long time. We want to fail fast and loudly.

In addition, sets the OPA reporting addres to be http://localhost:8181 rather than opa.traceable.ai

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
