### PR TITLE
🐛 Charset quality factor

### DIFF
--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/instrumentation/utils/ContentTypeUtils.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/instrumentation/utils/ContentTypeUtils.java
@@ -21,6 +21,7 @@ public class ContentTypeUtils {
   private ContentTypeUtils() {}
 
   private static final String CHARSET_EQUALS = "charset=";
+  private static final String SEPARATOR = ";";
 
   /**
    * Returns true if the request/response with this content type should be captured.
@@ -51,7 +52,13 @@ public class ContentTypeUtils {
 
     int indexOfEncoding = indexOfCharset + CHARSET_EQUALS.length();
     if (indexOfEncoding < contentType.length()) {
-      return contentType.substring(indexOfEncoding, contentType.length());
+      String substring = contentType.substring(indexOfEncoding, contentType.length());
+      int semicolonIndex = substring.indexOf(SEPARATOR);
+      if (semicolonIndex == -1) {
+        return substring;
+      } else {
+        return substring.substring(0, semicolonIndex);
+      }
     }
     return null;
   }

--- a/javaagent-core/src/test/java/org/hypertrace/agent/core/instrumentation/utils/ContentTypeUtilsTest.java
+++ b/javaagent-core/src/test/java/org/hypertrace/agent/core/instrumentation/utils/ContentTypeUtilsTest.java
@@ -58,4 +58,15 @@ class ContentTypeUtilsTest {
     Assertions.assertEquals(
         null, ContentTypeUtils.parseCharset("Content-Type: application/json; charset="));
   }
+
+  /**
+   * Charsets can contain a "quality factor" per <a
+   * href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.2"></a>
+   */
+  @Test
+  void charsetWithCharsetQualityFactor() {
+    Assertions.assertEquals(
+        "utf-8",
+        ContentTypeUtils.parseCharset("Content-Type: application/json; charset=utf-8;q=.2"));
+  }
 }


### PR DESCRIPTION
## Description
Handle charset with quality factor. We came across this log message in a service that uses this java agent:
```
[opentelemetry.auto.trace 2021-06-29 16:43:30:382 +0000] [reactor-http-epoll-3] ERROR org.hypertrace.agent.core.instrumentation.utils.ContentTypeCharsetUtils - Could not parse encoding utf-8;q=.2 to charset, using default ISO-8859-1
```


### Testing
Added a unit test with a valid `Content-Type` header containing a charset with a quality factor. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

