### PR TITLE
🐛 Resolves bintray build error, bump minor version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,9 +47,6 @@ subprojects {
         mavenCentral()
         jcenter()
         maven {
-            url = uri("https://dl.bintray.com/open-telemetry/maven")
-        }
-        maven {
             url = uri("https://oss.jfrog.org/artifactory/oss-snapshot-local")
         }
     }


### PR DESCRIPTION
## Description
Removes the deprecated bintray repository as a result of an error that now occurs during build time. In addition, adds an empty commit to bump the minor version used by this project to 1.2.0 to reflect new functionality


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
