### PR TITLE
Upgrade otel 1 9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,10 +34,11 @@ subprojects {
     extra.set("versions", mapOf(
             // when updating these values, some values must also be updated in buildSrc as this map
             // cannot be accessed there
-            "opentelemetry" to "1.7.1",
-            "opentelemetry_java_agent" to "1.7.2-alpha",
-            "opentelemetry_java_agent_all" to "1.7.2",
-            "opentelemetry_gradle_plugin" to "0.8.0",
+            "opentelemetry" to "1.9.1",
+            "opentelemetry_proto" to "0.11.0-alpha",
+            "opentelemetry_java_agent" to "1.9.2-alpha",
+            "opentelemetry_java_agent_all" to "1.9.2",
+            "opentelemetry_gradle_plugin" to "1.9.2-alpha",
             "byte_buddy" to "1.11.2",
                 "slf4j" to "1.7.30"
     ))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ subprojects {
             "opentelemetry_java_agent" to "1.9.2-alpha",
             "opentelemetry_java_agent_all" to "1.9.2",
             "opentelemetry_gradle_plugin" to "1.9.2-alpha",
-            "byte_buddy" to "1.11.2",
+            "byte_buddy" to "1.11.22",
                 "slf4j" to "1.7.30"
     ))
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -37,10 +37,13 @@ dependencies {
   implementation("org.apache.maven", "maven-aether-provider", "3.3.9")
 
   implementation("com.google.guava", "guava", "20.0")
-  implementation("org.ow2.asm", "asm", "7.0-beta")
-  implementation("org.ow2.asm", "asm-tree", "7.0-beta")
+  implementation("org.ow2.asm", "asm", "9.1")
+  implementation("org.ow2.asm", "asm-tree", "9.1")
   implementation("org.apache.httpcomponents:httpclient:4.5.10")
-  implementation("net.bytebuddy:byte-buddy-gradle-plugin:1.11.2")
+  implementation("net.bytebuddy:byte-buddy-gradle-plugin:1.11.22") {
+    exclude(group = "net.bytebuddy", module = "byte-buddy")
+  }
+  implementation("net.bytebuddy:byte-buddy-dep:1.11.22")
 
   testImplementation("org.spockframework", "spock-core", "1.3-groovy-2.5")
   testImplementation("org.codehaus.groovy", "groovy-all", "2.5.8")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -27,9 +27,10 @@ repositories {
 dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
-  implementation("io.opentelemetry.javaagent:opentelemetry-muzzle:1.7.2-alpha")
-  implementation("io.opentelemetry.instrumentation.muzzle-generation:io.opentelemetry.instrumentation.muzzle-generation.gradle.plugin:0.8.0")
-  implementation("io.opentelemetry.instrumentation.muzzle-check:io.opentelemetry.instrumentation.muzzle-check.gradle.plugin:0.8.0")
+  val otelInstrumentationVersion = "1.9.2-alpha"
+  implementation("io.opentelemetry.javaagent:opentelemetry-muzzle:$otelInstrumentationVersion")
+  implementation("io.opentelemetry.instrumentation.muzzle-generation:io.opentelemetry.instrumentation.muzzle-generation.gradle.plugin:$otelInstrumentationVersion")
+  implementation("io.opentelemetry.instrumentation.muzzle-check:io.opentelemetry.instrumentation.muzzle-check.gradle.plugin:$otelInstrumentationVersion")
   implementation("com.github.jengelman.gradle.plugins:shadow:6.0.0")
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/AutoInstrumentationPlugin.java
+++ b/buildSrc/src/main/java/io/opentelemetry/instrumentation/gradle/AutoInstrumentationPlugin.java
@@ -57,7 +57,7 @@ public class AutoInstrumentationPlugin implements Plugin<Project> {
     dependencies.add("implementation", "org.slf4j:slf4j-api:1.7.30");
     dependencies.add("compileOnly", "com.google.auto.service:auto-service-annotations:1.0");
     dependencies.add("annotationProcessor", "com.google.auto.service:auto-service:1.0");
-    dependencies.add("implementation", "net.bytebuddy:byte-buddy:" + versions.get("byte_buddy"));
+    dependencies.add("implementation", "net.bytebuddy:byte-buddy-dep:" + versions.get("byte_buddy"));
     dependencies.add("implementation",
         "io.opentelemetry:opentelemetry-api:" + versions.get("opentelemetry"));
     dependencies.add("implementation",

--- a/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/apachehttpclient/v4_0/ApacheHttpClientObjectRegistry.java
+++ b/instrumentation/apache-httpclient-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/apachehttpclient/v4_0/ApacheHttpClientObjectRegistry.java
@@ -18,13 +18,12 @@ package io.opentelemetry.javaagent.instrumentation.hypertrace.apachehttpclient.v
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.instrumentation.api.caching.Cache;
+import io.opentelemetry.instrumentation.api.cache.Cache;
 import org.apache.http.HttpEntity;
 
 public class ApacheHttpClientObjectRegistry {
 
-  public static final Cache<HttpEntity, SpanAndAttributeKey> entityToSpan =
-      Cache.builder().setWeakKeys().build();
+  public static final Cache<HttpEntity, SpanAndAttributeKey> entityToSpan = Cache.weak();
 
   public static class SpanAndAttributeKey {
     public final Span span;

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/server/HttpServerResponseTracingHandler.java
@@ -100,7 +100,8 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
     if (msg instanceof HttpResponse) {
       HttpResponse httpResponse = (HttpResponse) msg;
       span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, httpResponse.getStatus().code());
-      span.setStatus(HttpStatusConverter.statusFromHttpStatus(httpResponse.getStatus().code()));
+      span.setStatus(
+          HttpStatusConverter.SERVER.statusFromHttpStatus(httpResponse.getStatus().code()));
     }
     if (msg instanceof LastHttpContent) {
       span.end();

--- a/instrumentation/netty/netty-4.1/build.gradle.kts
+++ b/instrumentation/netty/netty-4.1/build.gradle.kts
@@ -43,6 +43,7 @@ val versions: Map<String, String> by extra
 
 dependencies {
     implementation("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-netty-4-common:${versions["opentelemetry_java_agent"]}")
+    implementation("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-netty-4.1-common:${versions["opentelemetry_java_agent"]}")
     implementation("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-netty-4.1:${versions["opentelemetry_java_agent"]}")
     library("io.netty:netty-codec-http:4.1.0.Final")
 

--- a/instrumentation/netty/netty-4.1/build.gradle.kts
+++ b/instrumentation/netty/netty-4.1/build.gradle.kts
@@ -42,7 +42,6 @@ afterEvaluate{
 val versions: Map<String, String> by extra
 
 dependencies {
-    implementation("io.opentelemetry.instrumentation:opentelemetry-netty-4.1:${versions["opentelemetry_java_agent"]}")
     implementation("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-netty-4-common:${versions["opentelemetry_java_agent"]}")
     implementation("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-netty-4.1:${versions["opentelemetry_java_agent"]}")
     library("io.netty:netty-codec-http:4.1.0.Final")

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/client/HttpClientRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/client/HttpClientRequestTracingHandler.java
@@ -51,7 +51,8 @@ public class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapt
     Channel channel = ctx.channel();
     Context context =
         channel
-            .attr(io.opentelemetry.instrumentation.netty.v4_1.AttributeKeys.CLIENT_CONTEXT)
+            .attr(
+                io.opentelemetry.javaagent.instrumentation.netty.v4_1.AttributeKeys.CLIENT_CONTEXT)
             .get();
     if (context == null) {
       ctx.write(msg, prm);

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerBlockingRequestHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerBlockingRequestHandler.java
@@ -38,7 +38,8 @@ public class HttpServerBlockingRequestHandler extends ChannelInboundHandlerAdapt
     Channel channel = ctx.channel();
     Context context =
         channel
-            .attr(io.opentelemetry.instrumentation.netty.v4_1.AttributeKeys.SERVER_CONTEXT)
+            .attr(
+                io.opentelemetry.javaagent.instrumentation.netty.v4_1.AttributeKeys.SERVER_CONTEXT)
             .get();
     if (context == null) {
       ctx.fireChannelRead(msg);

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerRequestTracingHandler.java
@@ -50,7 +50,8 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     Channel channel = ctx.channel();
     Context context =
         channel
-            .attr(io.opentelemetry.instrumentation.netty.v4_1.AttributeKeys.SERVER_CONTEXT)
+            .attr(
+                io.opentelemetry.javaagent.instrumentation.netty.v4_1.AttributeKeys.SERVER_CONTEXT)
             .get();
     if (context == null) {
       ctx.fireChannelRead(msg);

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerResponseTracingHandler.java
@@ -52,7 +52,8 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
   public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise prm) {
     Context context =
         ctx.channel()
-            .attr(io.opentelemetry.instrumentation.netty.v4_1.AttributeKeys.SERVER_CONTEXT)
+            .attr(
+                io.opentelemetry.javaagent.instrumentation.netty.v4_1.AttributeKeys.SERVER_CONTEXT)
             .get();
     if (context == null) {
       ctx.write(msg, prm);
@@ -99,7 +100,7 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
     if (msg instanceof HttpResponse) {
       HttpResponse httpResponse = (HttpResponse) msg;
       span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, httpResponse.status().code());
-      span.setStatus(HttpStatusConverter.statusFromHttpStatus(httpResponse.status().code()));
+      span.setStatus(HttpStatusConverter.SERVER.statusFromHttpStatus(httpResponse.status().code()));
     }
     if (msg instanceof LastHttpContent) {
       span.end();

--- a/instrumentation/struts-2.3/build.gradle.kts
+++ b/instrumentation/struts-2.3/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.internal.Cast.uncheckedCast
-
 plugins {
     `java-library`
     id("io.opentelemetry.instrumentation.auto-instrumentation")
@@ -16,7 +14,6 @@ dependencies {
     testImplementation("io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-servlet-3.0:${versions["opentelemetry_java_agent"]}")
     testImplementation("org.apache.struts:struts2-core:2.3.1")
     testImplementation("org.apache.struts:struts2-json-plugin:2.3.1")
-    testImplementation("org.apache.struts:struts2-convention-plugin:2.3.1")
     testImplementation("org.eclipse.jetty:jetty-server:8.0.0.v20110901")
     testImplementation("org.eclipse.jetty:jetty-servlet:8.0.0.v20110901")
     testImplementation("javax.servlet:javax.servlet-api:3.0.1")

--- a/instrumentation/struts-2.3/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/struts/Struts2Action.java
+++ b/instrumentation/struts-2.3/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/struts/Struts2Action.java
@@ -17,11 +17,7 @@
 package io.opentelemetry.javaagent.instrumentation.hypertrace.struts;
 
 import com.opensymphony.xwork2.ActionSupport;
-import org.apache.struts2.convention.annotation.ParentPackage;
-import org.apache.struts2.convention.annotation.Result;
 
-@Result(type = "json")
-@ParentPackage("json-default")
 public class Struts2Action extends ActionSupport {
 
   private String jsonString = "{'balance':1000.21,'is_vip':true,'num':100,'name':'foo'}";

--- a/javaagent-tooling/build.gradle.kts
+++ b/javaagent-tooling/build.gradle.kts
@@ -21,8 +21,7 @@ dependencies {
     instrumentationMuzzle("io.opentelemetry.instrumentation:gradle-plugins:${versions["opentelemetry_gradle_plugin"]}")
     instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-bootstrap:${versions["opentelemetry_java_agent"]}")
     instrumentationMuzzle("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions["opentelemetry_java_agent"]}")
-    instrumentationMuzzle("net.bytebuddy:byte-buddy:1.11.2")
-    instrumentationMuzzle("net.bytebuddy:byte-buddy-agent:1.11.2")
+    instrumentationMuzzle("net.bytebuddy:byte-buddy-dep:1.11.22")
     instrumentationMuzzle("com.google.auto.service:auto-service:1.0")
     instrumentationMuzzle("org.slf4j:slf4j-api:${versions["slf4j"]}")
 }

--- a/otel-extensions/build.gradle.kts
+++ b/otel-extensions/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 
     implementation("org.slf4j:slf4j-api:${versions["slf4j"]}")
     compileOnly("com.google.auto.service:auto-service-annotations:1.0")
-    implementation("net.bytebuddy:byte-buddy:${versions["byte_buddy"]}")
+    implementation("net.bytebuddy:byte-buddy-dep:${versions["byte_buddy"]}")
     annotationProcessor("com.google.auto.service:auto-service:1.0")
 
 

--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies{
     testImplementation("org.testcontainers:testcontainers:1.15.2")
     testImplementation("com.squareup.okhttp3:okhttp:4.9.0")
     testImplementation("org.awaitility:awaitility:4.0.3")
-    testImplementation("io.opentelemetry:opentelemetry-proto:${versions["opentelemetry"]}-alpha")
+    testImplementation("io.opentelemetry.proto:opentelemetry-proto:${versions["opentelemetry_proto"]}")
     testImplementation("io.grpc:grpc-core:1.36.1") // needed at runtime to send gRPC requests to the gRPC app
     testRuntimeOnly("io.grpc:grpc-netty-shaded:1.36.1") // needed at runtime to send gRPC requests to the gRPC app
     testRuntimeOnly("io.grpc:grpc-stub:1.36.1") // needed at runtime to send gRPC requests to the gRPC app


### PR DESCRIPTION
## Description
- Upgrades OpenTelemetry to 1.9.X
- Upgrades byte buddy to 1.11.22
- minor refactors to instrumentation modules due to API changes
- Removal of the struts2 convention plugin from the struts2 test. This is removed because this plugin depends on a very low version of ASM which causes conflicts when the agent and struts2 are both in the same class loader. In production, the agent's version of ASM is not in the application class loader, so these two versions can exist without conflict. In the instrumentation unit test suite, we currently don't put agent dependencies on a different class loader (though we will in the future when we migrate to the otel test harness

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
