### PR TITLE
:arrow_up: Upgrade otel 1.11.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,11 +34,11 @@ subprojects {
     extra.set("versions", mapOf(
             // when updating these values, some values must also be updated in buildSrc as this map
             // cannot be accessed there
-            "opentelemetry" to "1.10.1",
+            "opentelemetry" to "1.11.0",
             "opentelemetry_proto" to "0.11.0-alpha",
-            "opentelemetry_java_agent" to "1.10.1-alpha",
-            "opentelemetry_java_agent_all" to "1.10.1",
-            "opentelemetry_gradle_plugin" to "1.10.1-alpha",
+            "opentelemetry_java_agent" to "1.11.0-alpha",
+            "opentelemetry_java_agent_all" to "1.11.0",
+            "opentelemetry_gradle_plugin" to "1.11.0-alpha",
             "byte_buddy" to "1.12.6",
                 "slf4j" to "1.7.32"
     ))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,11 @@ allprojects {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    tasks.compileJava {
+        options.compilerArgs.add("-Werror")
+    }
+
+
     tasks.withType<JavaCompile> {
         options.compilerArgs.add("-Xlint:unchecked")
         options.isDeprecation = true

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -27,7 +27,7 @@ repositories {
 dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
-  val otelInstrumentationVersion = "1.10.1-alpha"
+  val otelInstrumentationVersion = "1.11.0-alpha"
   implementation("io.opentelemetry.javaagent:opentelemetry-muzzle:$otelInstrumentationVersion")
   implementation("io.opentelemetry.instrumentation.muzzle-generation:io.opentelemetry.instrumentation.muzzle-generation.gradle.plugin:$otelInstrumentationVersion")
   implementation("io.opentelemetry.instrumentation.muzzle-check:io.opentelemetry.instrumentation.muzzle-check.gradle.plugin:$otelInstrumentationVersion")

--- a/instrumentation/apache-httpasyncclient-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/apachehttpasyncclient/ApacheAsyncClientInstrumentationModule.java
+++ b/instrumentation/apache-httpasyncclient-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/apachehttpasyncclient/ApacheAsyncClientInstrumentationModule.java
@@ -27,7 +27,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.instrumentation.api.tracer.ClientSpan;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
@@ -173,7 +172,7 @@ public class ApacheAsyncClientInstrumentationModule extends InstrumentationModul
         Object getContextResult = getContext.invoke(wrappedFutureCallback);
         if (getContextResult instanceof Context) {
           Context context = (Context) getContextResult;
-          Span clientSpan = ClientSpan.fromContextOrNull(context);
+          Span clientSpan = Span.fromContextOrNull(context);
           bodyCaptureDelegatingCallback.clientContext = context;
           ApacheHttpClientUtils.traceRequest(clientSpan, request);
         }

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/client/HttpClientResponseTracingHandler.java
@@ -26,9 +26,9 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.Attribute;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpStatusConverter;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.netty.v4_0.AttributeKeys;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.netty.v4_0.DataCaptureUtils;
 import io.opentelemetry.javaagent.instrumentation.netty.v4_0.client.NettyClientSingletons;
@@ -100,9 +100,9 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     }
     if (msg instanceof HttpResponse) {
       HttpResponse httpResponse = (HttpResponse) msg;
-      span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, httpResponse.getStatus().code());
-      span.setStatus(
-          HttpStatusConverter.CLIENT.statusFromHttpStatus(httpResponse.getStatus().code()));
+      int code = httpResponse.getStatus().code();
+      span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, code);
+      span.setStatus(code >= 100 && code < 400 ? StatusCode.UNSET : StatusCode.ERROR);
     }
     if (msg instanceof LastHttpContent) {
       span.end();

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/server/HttpServerResponseTracingHandler.java
@@ -26,9 +26,9 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.Attribute;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpStatusConverter;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.netty.v4_0.AttributeKeys;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.netty.v4_0.DataCaptureUtils;
 import io.opentelemetry.javaagent.instrumentation.netty.v4_0.server.NettyServerSingletons;
@@ -99,9 +99,9 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
     }
     if (msg instanceof HttpResponse) {
       HttpResponse httpResponse = (HttpResponse) msg;
-      span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, httpResponse.getStatus().code());
-      span.setStatus(
-          HttpStatusConverter.SERVER.statusFromHttpStatus(httpResponse.getStatus().code()));
+      int code = httpResponse.getStatus().code();
+      span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, code);
+      span.setStatus(code >= 100 && code < 500 ? StatusCode.UNSET : StatusCode.ERROR);
     }
     if (msg instanceof LastHttpContent) {
       span.end();

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/client/HttpClientResponseTracingHandler.java
@@ -100,7 +100,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     }
     if (msg instanceof HttpResponse) {
       HttpResponse httpResponse = (HttpResponse) msg;
-      int code = httpResponse.getStatus().code();
+      int code = httpResponse.status().code();
       span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, code);
       span.setStatus(code >= 100 && code < 400 ? StatusCode.UNSET : StatusCode.ERROR);
     }

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/client/HttpClientResponseTracingHandler.java
@@ -26,9 +26,9 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.Attribute;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpStatusConverter;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.netty.v4_1.AttributeKeys;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.netty.v4_1.DataCaptureUtils;
 import io.opentelemetry.javaagent.instrumentation.netty.v4_1.client.NettyClientSingletons;
@@ -100,9 +100,9 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     }
     if (msg instanceof HttpResponse) {
       HttpResponse httpResponse = (HttpResponse) msg;
-      span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, httpResponse.getStatus().code());
-      span.setStatus(
-          HttpStatusConverter.CLIENT.statusFromHttpStatus(httpResponse.getStatus().code()));
+      int code = httpResponse.getStatus().code();
+      span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, code);
+      span.setStatus(code >= 100 && code < 400 ? StatusCode.UNSET : StatusCode.ERROR);
     }
     if (msg instanceof LastHttpContent) {
       span.end();

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerResponseTracingHandler.java
@@ -99,7 +99,7 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
     }
     if (msg instanceof HttpResponse) {
       HttpResponse httpResponse = (HttpResponse) msg;
-      int code = httpResponse.getStatus().code();
+      int code = httpResponse.status().code();
       span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, code);
       span.setStatus(code >= 100 && code < 500 ? StatusCode.UNSET : StatusCode.ERROR);
     }

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerResponseTracingHandler.java
@@ -26,9 +26,9 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.Attribute;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpStatusConverter;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.netty.v4_1.AttributeKeys;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.netty.v4_1.DataCaptureUtils;
 import io.opentelemetry.javaagent.instrumentation.netty.v4_1.server.NettyServerSingletons;
@@ -99,8 +99,9 @@ public class HttpServerResponseTracingHandler extends ChannelOutboundHandlerAdap
     }
     if (msg instanceof HttpResponse) {
       HttpResponse httpResponse = (HttpResponse) msg;
-      span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, httpResponse.status().code());
-      span.setStatus(HttpStatusConverter.SERVER.statusFromHttpStatus(httpResponse.status().code()));
+      int code = httpResponse.getStatus().code();
+      span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, code);
+      span.setStatus(code >= 100 && code < 500 ? StatusCode.UNSET : StatusCode.ERROR);
     }
     if (msg instanceof LastHttpContent) {
       span.end();

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/FilterComponentInstaller.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/FilterComponentInstaller.java
@@ -19,6 +19,7 @@ package org.hypertrace.agent.otel.extensions;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.extension.AgentListener;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hypertrace.agent.config.v1.Config.AgentConfig;
@@ -29,7 +30,8 @@ import org.hypertrace.agent.otel.extensions.config.HypertraceConfig;
 public class FilterComponentInstaller implements AgentListener {
 
   @Override
-  public void beforeAgent(Config config) {
+  public void beforeAgent(
+      Config config, AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk) {
     AgentConfig agentConfig = HypertraceConfig.get();
     List<String> jarPaths =
         agentConfig.getJavaagent().getFilterJarPathsList().stream()
@@ -38,7 +40,4 @@ public class FilterComponentInstaller implements AgentListener {
     // resolves filter via service loader resolution
     FilterRegistry.initialize(jarPaths);
   }
-
-  @Override
-  public void afterAgent(Config config) {}
 }

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/InstrumentationConfigInstaller.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/InstrumentationConfigInstaller.java
@@ -19,14 +19,16 @@ package org.hypertrace.agent.otel.extensions.config;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.instrumentation.api.config.Config;
 import io.opentelemetry.javaagent.extension.AgentListener;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import org.hypertrace.agent.core.config.InstrumentationConfig.ConfigProvider;
 
 @AutoService(AgentListener.class)
 public class InstrumentationConfigInstaller implements AgentListener {
 
   @Override
-  public void beforeAgent(Config config) {
-    // get initializes singleton
+  public void beforeAgent(
+      Config config,
+      AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk) { // get initializes singleton
     ConfigProvider.get();
   }
 }

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/HypertraceCustomizerProvider.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/HypertraceCustomizerProvider.java
@@ -17,9 +17,8 @@
 package org.hypertrace.agent.otel.extensions.processor;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer;
-import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 
 /**
  * This is a workaround to add container ID tags to spans when Zipkin exporter is used. Zipkin
@@ -29,12 +28,13 @@ import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
  * <p>Remove this once we migrate to OTEL exporter
  * https://github.com/hypertrace/javaagent/issues/132
  */
-@AutoService(SdkTracerProviderConfigurer.class)
-public class HypertraceTracerCustomizer implements SdkTracerProviderConfigurer {
+@AutoService(AutoConfigurationCustomizerProvider.class)
+public class HypertraceCustomizerProvider implements AutoConfigurationCustomizerProvider {
 
   @Override
-  public void configure(
-      SdkTracerProviderBuilder tracerProvider, ConfigProperties configProperties) {
-    tracerProvider.addSpanProcessor(new AddTagsSpanProcessor());
+  public void customize(AutoConfigurationCustomizer autoConfiguration) {
+    autoConfiguration.addTracerProviderCustomizer(
+        (sdkTracerProviderBuilder, configProperties) ->
+            sdkTracerProviderBuilder.addSpanProcessor(new AddTagsSpanProcessor()));
   }
 }

--- a/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/org/hypertrace/agent/smoketest/SpringBootSmokeTest.java
@@ -175,12 +175,8 @@ public class SpringBootSmokeTest extends AbstractSmokeTest {
     ArrayList<ExportMetricsServiceRequest> metrics = new ArrayList<>(waitForMetrics());
     Assertions.assertTrue(hasMetricNamed("otlp.exporter.seen", metrics));
     Assertions.assertTrue(hasMetricNamed("otlp.exporter.exported", metrics));
-    /*
-    These metrics stopped being reported in OTEL SDK 1.10.0, due to a bug in the OpenTelemetry SDK
-    Autoconfigure project https://github.com/open-telemetry/opentelemetry-java/issues/4109
     Assertions.assertTrue(hasMetricNamed("processedSpans", metrics));
     Assertions.assertTrue(hasMetricNamed("queueSize", metrics));
-     */
     Assertions.assertTrue(hasMetricNamed("runtime.jvm.gc.count", metrics));
     Assertions.assertTrue(hasMetricNamed("runtime.jvm.gc.time", metrics));
     Assertions.assertTrue(hasMetricNamed("runtime.jvm.memory.pool", metrics));

--- a/testing-common/src/testFixtures/java/org/hypertrace/agent/testing/AbstractInstrumenterTest.java
+++ b/testing-common/src/testFixtures/java/org/hypertrace/agent/testing/AbstractInstrumenterTest.java
@@ -64,6 +64,7 @@ public abstract class AbstractInstrumenterTest {
     System.setProperty("otel.internal.failOnContextLeak", "true");
     System.setProperty("io.opentelemetry.javaagent.slf4j.simpleLogger.log.muzzleMatcher", "warn");
     System.setProperty("otel.traces.exporter", "none");
+    System.setProperty("otel.metrics.exporter", "none");
 
     INSTRUMENTATION = ByteBuddyAgent.install();
     InstrumentationHolder.setInstrumentation(INSTRUMENTATION);

--- a/testing-common/src/testFixtures/java/org/hypertrace/agent/testing/TestSdkTracerProviderConfigurer.java
+++ b/testing-common/src/testFixtures/java/org/hypertrace/agent/testing/TestSdkTracerProviderConfigurer.java
@@ -17,15 +17,16 @@
 package org.hypertrace.agent.testing;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.traces.SdkTracerProviderConfigurer;
-import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 
-@AutoService(SdkTracerProviderConfigurer.class)
-public final class TestSdkTracerProviderConfigurer implements SdkTracerProviderConfigurer {
+@AutoService(AutoConfigurationCustomizerProvider.class)
+public final class TestSdkTracerProviderConfigurer implements AutoConfigurationCustomizerProvider {
 
   @Override
-  public void configure(SdkTracerProviderBuilder tracerProviderBuilder, ConfigProperties config) {
-    tracerProviderBuilder.addSpanProcessor(AbstractInstrumenterTest.TEST_WRITER);
+  public void customize(AutoConfigurationCustomizer autoConfiguration) {
+    autoConfiguration.addTracerProviderCustomizer(
+        (sdkTracerProviderBuilder, configProperties) ->
+            sdkTracerProviderBuilder.addSpanProcessor(AbstractInstrumenterTest.TEST_WRITER));
   }
 }


### PR DESCRIPTION
## Description
- Upgrades otel java to `1.11.0`
- refactor usages of deprecated and/or removed otel APIs
- Treat compiler warnings as errors in the main source set to better raise visibility of things like deprecation warnings that we might otherwise miss

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
