### PR TITLE
🐛 Fix incorrect metrics endpoint

### DIFF
--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/EnvironmentConfig.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/EnvironmentConfig.java
@@ -137,11 +137,11 @@ public class EnvironmentConfig {
     String metricReporterAddress = getProperty(REPORTING_METRIC_ENDPOINT);
     if (metricReporterAddress != null) {
       builder.setMetricEndpoint(StringValue.newBuilder().setValue(metricReporterAddress).build());
-    } else if (TraceReporterType.OTLP.equals(builder.getTraceReporterType())
+    } else if (reporterAddress != null
+        && TraceReporterType.OTLP.equals(builder.getTraceReporterType())
         && builder.getMetricReporterType() == MetricReporterType.METRIC_REPORTER_TYPE_OTLP) {
       // If metric endpoint is not given, use the reporter endpoint if it is otlp
-      builder.setMetricEndpoint(
-          StringValue.newBuilder().setValue(builder.getEndpoint().getValue()).build());
+      builder.setMetricEndpoint(StringValue.newBuilder().setValue(reporterAddress).build());
     }
     String secure = getProperty(REPORTING_SECURE);
     if (secure != null) {

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/EnvironmentConfig.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/EnvironmentConfig.java
@@ -137,11 +137,11 @@ public class EnvironmentConfig {
     String metricReporterAddress = getProperty(REPORTING_METRIC_ENDPOINT);
     if (metricReporterAddress != null) {
       builder.setMetricEndpoint(StringValue.newBuilder().setValue(metricReporterAddress).build());
-    } else if (reporterAddress != null
-        && TraceReporterType.OTLP.equals(builder.getTraceReporterType())
+    } else if (TraceReporterType.OTLP.equals(builder.getTraceReporterType())
         && builder.getMetricReporterType() == MetricReporterType.METRIC_REPORTER_TYPE_OTLP) {
       // If metric endpoint is not given, use the reporter endpoint if it is otlp
-      builder.setMetricEndpoint(StringValue.newBuilder().setValue(reporterAddress).build());
+      builder.setMetricEndpoint(
+          StringValue.newBuilder().setValue(builder.getEndpoint().getValue()).build());
     }
     String secure = getProperty(REPORTING_SECURE);
     if (secure != null) {

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfig.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfig.java
@@ -140,6 +140,9 @@ public class HypertraceConfig {
     if (!builder.hasEndpoint()) {
       builder.setEndpoint(StringValue.newBuilder().setValue(DEFAULT_REPORTING_ENDPOINT).build());
     }
+    if (builder.getTraceReporterType().equals(TraceReporterType.UNSPECIFIED)) {
+      builder.setTraceReporterType(TraceReporterType.OTLP);
+    }
     if (!builder.hasMetricEndpoint()) {
       if (TraceReporterType.OTLP.equals(builder.getTraceReporterType())) {
         // If trace reporter type is OTLP, use the same endpoint for metrics
@@ -148,9 +151,6 @@ public class HypertraceConfig {
         builder.setMetricEndpoint(
             StringValue.newBuilder().setValue(DEFAULT_REPORTING_ENDPOINT).build());
       }
-    }
-    if (builder.getTraceReporterType().equals(TraceReporterType.UNSPECIFIED)) {
-      builder.setTraceReporterType(TraceReporterType.OTLP);
     }
     if (builder
         .getMetricReporterType()

--- a/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
+++ b/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
@@ -216,6 +216,7 @@ public class HypertraceConfigTest {
     Assertions.assertEquals(
         TraceReporterType.OTLP, agentConfig.getReporting().getTraceReporterType());
     String expectedReportingEndpoint = "http://example.com:4317";
+    // VERIFY the trace reporting and metric reporting endpoints are both the specified value
     Assertions.assertEquals(
         expectedReportingEndpoint, agentConfig.getReporting().getEndpoint().getValue());
     Assertions.assertEquals(
@@ -224,15 +225,17 @@ public class HypertraceConfigTest {
 
   @Test
   void nonDefaultMetricsEndpoint() throws IOException {
-    // GIVEN a config file with a non-default reporting endpoint
+    // GIVEN a config file with a non-default metric reporting endpoint
     URL resource = getClass().getClassLoader().getResource("nonDefaultMetricsEndpoint.yaml");
     // WHEN we load the config
     AgentConfig agentConfig = HypertraceConfig.load(resource.getPath());
     // VERIFY the trace reporting type is OTLP
     Assertions.assertEquals(
         TraceReporterType.OTLP, agentConfig.getReporting().getTraceReporterType());
+    // VERIFY the trace reporting endpoint is still the default value
     Assertions.assertEquals(
         "http://localhost:4317", agentConfig.getReporting().getEndpoint().getValue());
+    // VERIFY the metric reporting endpoint is the specified value
     Assertions.assertEquals(
         "http://example.com:4317", agentConfig.getReporting().getMetricEndpoint().getValue());
   }

--- a/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
+++ b/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
@@ -205,4 +205,20 @@ public class HypertraceConfigTest {
         HypertraceConfig.DEFAULT_REPORTING_ENDPOINT,
         agentConfig.getReporting().getMetricEndpoint().getValue());
   }
+
+  @Test
+  void nonDefaultReportingEndpoint() throws IOException {
+    // GIVEN a config file with a non-default reporting endpoint
+    URL resource = getClass().getClassLoader().getResource("nonDefaultReportingEndpoint.yaml");
+    // WHEN we load the config
+    AgentConfig agentConfig = HypertraceConfig.load(resource.getPath());
+    // VERIFY the trace reporting type is OTLP
+    Assertions.assertEquals(
+        TraceReporterType.OTLP, agentConfig.getReporting().getTraceReporterType());
+    String expectedReportingEndpoint = "http://example.com:4317";
+    Assertions.assertEquals(
+        expectedReportingEndpoint, agentConfig.getReporting().getEndpoint().getValue());
+    Assertions.assertEquals(
+        expectedReportingEndpoint, agentConfig.getReporting().getMetricEndpoint().getValue());
+  }
 }

--- a/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
+++ b/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
@@ -221,4 +221,19 @@ public class HypertraceConfigTest {
     Assertions.assertEquals(
         expectedReportingEndpoint, agentConfig.getReporting().getMetricEndpoint().getValue());
   }
+
+  @Test
+  void nonDefaultMetricsEndpoint() throws IOException {
+    // GIVEN a config file with a non-default reporting endpoint
+    URL resource = getClass().getClassLoader().getResource("nonDefaultMetricsEndpoint.yaml");
+    // WHEN we load the config
+    AgentConfig agentConfig = HypertraceConfig.load(resource.getPath());
+    // VERIFY the trace reporting type is OTLP
+    Assertions.assertEquals(
+        TraceReporterType.OTLP, agentConfig.getReporting().getTraceReporterType());
+    Assertions.assertEquals(
+        "http://localhost:4317", agentConfig.getReporting().getEndpoint().getValue());
+    Assertions.assertEquals(
+        "http://example.com:4317", agentConfig.getReporting().getMetricEndpoint().getValue());
+  }
 }

--- a/otel-extensions/src/test/resources/nonDefaultMetricsEndpoint.yaml
+++ b/otel-extensions/src/test/resources/nonDefaultMetricsEndpoint.yaml
@@ -1,0 +1,3 @@
+service_name: service
+reporting:
+  metric_endpoint: http://example.com:4317

--- a/otel-extensions/src/test/resources/nonDefaultReportingEndpoint.yaml
+++ b/otel-extensions/src/test/resources/nonDefaultReportingEndpoint.yaml
@@ -1,0 +1,3 @@
+service_name: service
+reporting:
+  endpoint: http://example.com:4317


### PR DESCRIPTION
## Description
Fixes bug where if a non-default reporting endpoint is supplied via YAML, the metric endpoint is still set to the default value. We had somewhat accounted for this, but only if the trace reporting type was OTLP.


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

n/a
