### PR TITLE
Support configurable Allowed Content Types within Hypertrace Javaagent

### DIFF
--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/config/DataCaptureConfig.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/config/DataCaptureConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.core.config;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Interface implemented by classes which can provide the names of the content types which can be
+ * captured.
+ */
+public interface DataCaptureConfig {
+
+  String[] getAllowedContentTypes();
+
+  /** This class return an implementation of the DataCaptureConfig interface */
+  class ConfigProvider {
+    private static final Logger logger = LoggerFactory.getLogger(ConfigProvider.class);
+    private static volatile DataCaptureConfig dataCaptureConfig;
+
+    /**
+     * Locates the first concrete implementation of the DataCaptureConfig interface.
+     *
+     * @return
+     */
+    private static DataCaptureConfig load() {
+      ServiceLoader<DataCaptureConfig> configs = ServiceLoader.load(DataCaptureConfig.class);
+      Iterator<DataCaptureConfig> iterator = configs.iterator();
+      if (!iterator.hasNext()) {
+        logger.error("Failed to load data capture config");
+        return null;
+      }
+      return iterator.next();
+    }
+
+    /**
+     * @return an implementation of the DataCaptureConfig interface, or null if one cannot be found
+     */
+    public static DataCaptureConfig get() {
+      if (dataCaptureConfig == null) {
+        synchronized (ConfigProvider.class) {
+          if (dataCaptureConfig == null) {
+            dataCaptureConfig = load();
+          }
+        }
+      }
+      return dataCaptureConfig;
+    }
+  }
+}

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/DataCaptureConfigImpl.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/DataCaptureConfigImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.otel.extensions.config;
+
+import com.google.auto.service.AutoService;
+import com.google.protobuf.StringValue;
+import java.util.List;
+import org.hypertrace.agent.config.v1.Config;
+import org.hypertrace.agent.core.config.DataCaptureConfig;
+
+/**
+ * An implementation of the DataCaptureConfig interface, which can provide the names of the content
+ * types that can be captured.
+ */
+@AutoService(DataCaptureConfig.class)
+public class DataCaptureConfigImpl implements DataCaptureConfig {
+
+  private final Config.AgentConfig agentConfig = HypertraceConfig.get();
+
+  private final Config.DataCapture dataCaptureConfig =
+      (agentConfig != null) ? agentConfig.getDataCapture() : null;
+
+  private String[] allAllowedContentTypes;
+
+  public DataCaptureConfigImpl() {
+    super();
+  }
+
+  public String[] getAllowedContentTypes() {
+    if (allAllowedContentTypes != null) {
+      return allAllowedContentTypes;
+    }
+
+    return loadContentTypes();
+  }
+
+  /**
+   * Determines the content types that should be captured.
+   *
+   * @return an array of the content types
+   */
+  private synchronized String[] loadContentTypes() {
+    if (allAllowedContentTypes == null) {
+      if (dataCaptureConfig == null) {
+        allAllowedContentTypes = new String[0];
+      } else {
+        List<StringValue> listOfTypes = dataCaptureConfig.getAllowedContentTypesList();
+        String[] allAllowedContentTypes = new String[listOfTypes.size()];
+        int idx = 0;
+        for (StringValue nextStringValue : listOfTypes) {
+          allAllowedContentTypes[idx] = nextStringValue.getValue();
+          idx++;
+        }
+
+        this.allAllowedContentTypes = allAllowedContentTypes;
+      }
+    }
+
+    return allAllowedContentTypes;
+  }
+}

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/DataCaptureConfigInstaller.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/DataCaptureConfigInstaller.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.otel.extensions.config;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.api.config.Config;
+import io.opentelemetry.javaagent.extension.AgentListener;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import org.hypertrace.agent.core.config.DataCaptureConfig.ConfigProvider;
+
+/** An AgentListener implementation that initializes the DataCaptureConfig.ConfigProvider. */
+@AutoService(AgentListener.class)
+public class DataCaptureConfigInstaller implements AgentListener {
+
+  @Override
+  public void beforeAgent(
+      Config config, AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk) {
+    ConfigProvider.get();
+  }
+}

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfig.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfig.java
@@ -222,7 +222,8 @@ public class HypertraceConfig {
 
   /**
    * Creates a collection of objects consisting of the set of objects specified in the
-   * configuration, plus the default set of objects.
+   * configuration. If there are no objects in the configuration, the default set of objects is
+   * used.
    *
    * @param originalList the set of objects specified in the configuration
    * @param defaultSupplier a lambda which provides the default set of objects.
@@ -234,11 +235,11 @@ public class HypertraceConfig {
       List<T> originalList, Supplier<List<T>> defaultSupplier) {
     Set<T> returnSet = new HashSet<>();
 
-    if (originalList != null) {
+    if (originalList != null && originalList.size() > 0) {
       returnSet.addAll(originalList);
+    } else {
+      returnSet.addAll(defaultSupplier.get());
     }
-
-    returnSet.addAll(defaultSupplier.get());
 
     return returnSet;
   }

--- a/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/DataCaptureConfigTest.java
+++ b/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/DataCaptureConfigTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.otel.extensions.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+import org.hypertrace.agent.core.config.DataCaptureConfig;
+import org.junit.jupiter.api.Test;
+
+public class DataCaptureConfigTest {
+
+  @Test
+  public void instantiateViaServiceLoaderApi() {
+    final ServiceLoader<DataCaptureConfig> dataCaptureConfigs =
+        ServiceLoader.load(DataCaptureConfig.class);
+    final Iterator<DataCaptureConfig> iterator = dataCaptureConfigs.iterator();
+    assertTrue(iterator.hasNext());
+    final DataCaptureConfig dataCaptureConfig = iterator.next();
+    assertNotNull(dataCaptureConfig);
+    assertFalse(iterator.hasNext());
+  }
+}

--- a/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
+++ b/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
@@ -40,8 +40,7 @@ public class HypertraceConfigTest {
   private static final String[] EXPECTED_CONTENT_TYPES =
       new String[] {"json", "graphql", "xml", "x-www-form-urlencoded"};
 
-  private static final String[] EXPECTED_CONTENT_TYPES_WITH_ADDITIONS =
-      new String[] {"json", "graphql", "xml", "x-www-form-urlencoded", "foo", "bar"};
+  private static final String[] EXPECTED_CONTENT_TYPES_WITH_OVERRIDES = new String[] {"foo", "bar"};
 
   @Test
   public void defaultValues() throws IOException {
@@ -269,6 +268,6 @@ public class HypertraceConfigTest {
     URL resource = getClass().getClassLoader().getResource("nonDefaultDataCaptureConfig.yaml");
     AgentConfig agentConfig = HypertraceConfig.load(resource.getPath());
 
-    testAllowedContentTypes(agentConfig, EXPECTED_CONTENT_TYPES_WITH_ADDITIONS);
+    testAllowedContentTypes(agentConfig, EXPECTED_CONTENT_TYPES_WITH_OVERRIDES);
   }
 }

--- a/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
+++ b/otel-extensions/src/test/java/org/hypertrace/agent/otel/extensions/config/HypertraceConfigTest.java
@@ -23,6 +23,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.hypertrace.agent.config.v1.Config.AgentConfig;
 import org.hypertrace.agent.config.v1.Config.MetricReporterType;
 import org.hypertrace.agent.config.v1.Config.PropagationFormat;
@@ -34,6 +37,11 @@ import org.junitpioneer.jupiter.ClearSystemProperty;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 public class HypertraceConfigTest {
+  private static final String[] EXPECTED_CONTENT_TYPES =
+      new String[] {"json", "graphql", "xml", "x-www-form-urlencoded"};
+
+  private static final String[] EXPECTED_CONTENT_TYPES_WITH_ADDITIONS =
+      new String[] {"json", "graphql", "xml", "x-www-form-urlencoded", "foo", "bar"};
 
   @Test
   public void defaultValues() throws IOException {
@@ -77,6 +85,8 @@ public class HypertraceConfigTest {
         true, agentConfig.getDataCapture().getRpcBody().getResponse().getValue());
     Assertions.assertTrue(agentConfig.hasJavaagent());
     Assertions.assertEquals(0, agentConfig.getJavaagent().getFilterJarPathsCount());
+
+    testAllowedContentTypes(agentConfig, EXPECTED_CONTENT_TYPES);
   }
 
   @Test
@@ -99,6 +109,20 @@ public class HypertraceConfigTest {
 
     agentConfig = HypertraceConfig.load(jsonFile.getAbsolutePath());
     assertConfig(agentConfig);
+  }
+
+  private void testAllowedContentTypes(AgentConfig agentConfig, String[] expectedTypes) {
+
+    List<StringValue> listOfContentTypes =
+        agentConfig.getDataCapture().getAllowedContentTypesList();
+    Assertions.assertEquals(expectedTypes.length, listOfContentTypes.size());
+    Set<StringValue> allowedContentTypes = new HashSet<>();
+    allowedContentTypes.addAll(listOfContentTypes);
+
+    for (String nextType : expectedTypes) {
+      StringValue sv = StringValue.newBuilder().setValue(nextType).build();
+      Assertions.assertTrue(allowedContentTypes.contains(sv));
+    }
   }
 
   private void assertConfig(AgentConfig agentConfig) {
@@ -238,5 +262,13 @@ public class HypertraceConfigTest {
     // VERIFY the metric reporting endpoint is the specified value
     Assertions.assertEquals(
         "http://example.com:4317", agentConfig.getReporting().getMetricEndpoint().getValue());
+  }
+
+  @Test
+  public void nonDefaultDataCaptureConfigTest() throws IOException {
+    URL resource = getClass().getClassLoader().getResource("nonDefaultDataCaptureConfig.yaml");
+    AgentConfig agentConfig = HypertraceConfig.load(resource.getPath());
+
+    testAllowedContentTypes(agentConfig, EXPECTED_CONTENT_TYPES_WITH_ADDITIONS);
   }
 }

--- a/otel-extensions/src/test/resources/nonDefaultDataCaptureConfig.yaml
+++ b/otel-extensions/src/test/resources/nonDefaultDataCaptureConfig.yaml
@@ -1,0 +1,23 @@
+# use snake case for newly added fields
+service_name: service
+enabled: false
+propagationFormats:
+  - B3
+reporting:
+  endpoint: http://localhost:4317
+  metric_endpoint: http://localhost:4317
+  secure: true
+  trace_reporter_type: OTLP
+  metric_reporter_type: METRIC_REPORTER_TYPE_OTLP
+  cert_file: /foo/bar/example.pem
+dataCapture:
+  bodyMaxSizeBytes: 16
+  httpHeaders:
+    request: true
+    response: false
+  httpBody:
+  allowed_content_types: ["foo", "bar"]
+javaagent:
+  filter_jar_paths:
+    - /path1.jar
+    - /path/2/jar.jar


### PR DESCRIPTION
I had to start with a new PR and branch on this issue, due to the problems I was having pushing to the origin branch.  This, I believe, was due to submodules within the Hypertrace agent.  I think that these problems are fixed with this PR.