### PR TITLE
        Fix muzzle job for netty-4.0

### DIFF
--- a/instrumentation/netty/netty-4.0/build.gradle.kts
+++ b/instrumentation/netty/netty-4.0/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    id("com.google.osdetector") version "1.7.0"
     id("net.bytebuddy.byte-buddy")
     id("io.opentelemetry.instrumentation.auto-instrumentation")
     muzzle


### PR DESCRIPTION
The muzzle job is failing for netty-4.0:

> Could not resolve all files for configuration ':instrumentation:netty:netty-4.0:muzzle-AssertFail-io.netty-netty-all-4.1.64.Final'.
See https://docs.gradle.org/6.7/userguide/command_line_interface.html#sec:command_line_warnings
249 actionable tasks: 249 executed
   > Could not find netty-tcnative-2.0.39.Final-${os.detected.classifier}.jar (io.netty:netty-tcnative:2.0.39.Final).

The "com.google.osdetector" plugin was added to the build.gradle.kts file for netty-4.0.