### PR TITLE
Skip drop wizard 3.0.0/4.0.0 muzzle test

### DIFF
--- a/instrumentation/apache-httpclient-4.0/build.gradle.kts
+++ b/instrumentation/apache-httpclient-4.0/build.gradle.kts
@@ -24,6 +24,7 @@ muzzle {
         group = "io.dropwizard"
         module = "dropwizard-client"
         versions = "(,)"
+        skipVersions.add("4.0.0")
         assertInverse = true
     }
 }

--- a/instrumentation/apache-httpclient-4.0/build.gradle.kts
+++ b/instrumentation/apache-httpclient-4.0/build.gradle.kts
@@ -23,7 +23,7 @@ muzzle {
         // We want to support the dropwizard clients too.
         group = "io.dropwizard"
         module = "dropwizard-client"
-        versions = "(,)"
+        versions = "(,3.0)"
         assertInverse = true
     }
 }

--- a/instrumentation/apache-httpclient-4.0/build.gradle.kts
+++ b/instrumentation/apache-httpclient-4.0/build.gradle.kts
@@ -23,7 +23,7 @@ muzzle {
         // We want to support the dropwizard clients too.
         group = "io.dropwizard"
         module = "dropwizard-client"
-        versions = "(,4.0.0)"
+        versions = "(,3.0.0)"
         assertInverse = false
     }
 }

--- a/instrumentation/apache-httpclient-4.0/build.gradle.kts
+++ b/instrumentation/apache-httpclient-4.0/build.gradle.kts
@@ -23,7 +23,7 @@ muzzle {
         // We want to support the dropwizard clients too.
         group = "io.dropwizard"
         module = "dropwizard-client"
-        versions = "(,3.0)"
+        versions = "(,)"
         assertInverse = true
     }
 }

--- a/instrumentation/apache-httpclient-4.0/build.gradle.kts
+++ b/instrumentation/apache-httpclient-4.0/build.gradle.kts
@@ -16,7 +16,7 @@ muzzle {
     pass {
         group = "org.apache.httpcomponents"
         module = "httpclient"
-        versions = "[4.0,)"
+        versions = "[4.0,4.1)"
         assertInverse = true
     }
     pass {

--- a/instrumentation/apache-httpclient-4.0/build.gradle.kts
+++ b/instrumentation/apache-httpclient-4.0/build.gradle.kts
@@ -16,7 +16,7 @@ muzzle {
     pass {
         group = "org.apache.httpcomponents"
         module = "httpclient"
-        versions = "[4.0,4.1)"
+        versions = "[4.0,)"
         assertInverse = true
     }
     pass {

--- a/instrumentation/apache-httpclient-4.0/build.gradle.kts
+++ b/instrumentation/apache-httpclient-4.0/build.gradle.kts
@@ -23,9 +23,9 @@ muzzle {
         // We want to support the dropwizard clients too.
         group = "io.dropwizard"
         module = "dropwizard-client"
-        versions = "(,)"
+        versions = "(,4.0.0)"
+        assertInverse = false
         skipVersions.add("4.0.0")
-        assertInverse = true
     }
 }
 

--- a/instrumentation/apache-httpclient-4.0/build.gradle.kts
+++ b/instrumentation/apache-httpclient-4.0/build.gradle.kts
@@ -25,7 +25,6 @@ muzzle {
         module = "dropwizard-client"
         versions = "(,4.0.0)"
         assertInverse = false
-        skipVersions.add("4.0.0")
     }
 }
 

--- a/instrumentation/jaxrs-client-2.0/build.gradle.kts
+++ b/instrumentation/jaxrs-client-2.0/build.gradle.kts
@@ -17,7 +17,6 @@ muzzle {
         module = "dropwizard-client"
         versions = "[0.8.0,4.0.0)"
         assertInverse = false
-        skipVersions.add("4.0.0")
     }
 }
 

--- a/instrumentation/jaxrs-client-2.0/build.gradle.kts
+++ b/instrumentation/jaxrs-client-2.0/build.gradle.kts
@@ -15,7 +15,7 @@ muzzle {
         // We want to support the dropwizard clients too.
         group = "io.dropwizard"
         module = "dropwizard-client"
-        versions = "[0.8.0,4.0.0)"
+        versions = "[0.8.0,3.0.0)"
         assertInverse = false
     }
 }

--- a/instrumentation/jaxrs-client-2.0/build.gradle.kts
+++ b/instrumentation/jaxrs-client-2.0/build.gradle.kts
@@ -15,9 +15,9 @@ muzzle {
         // We want to support the dropwizard clients too.
         group = "io.dropwizard"
         module = "dropwizard-client"
-        versions = "[0.8.0,)"
-        // TODO this is set in OTEL
-//        assertInverse = true
+        versions = "[0.8.0,4.0.0)"
+        assertInverse = false
+        skipVersions.add("4.0.0")
     }
 }
 


### PR DESCRIPTION
Drop wizard 4.0.0 muzzle test fails.  4.0.0 (and 3.0.0) were introduced since we last ran 2 months ago.  3.0.0 passes. 