### PR TITLE
Add content type to additional data spans

### DIFF
--- a/instrumentation/java-streams/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/java/inputstream/InputStreamUtils.java
+++ b/instrumentation/java-streams/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/java/inputstream/InputStreamUtils.java
@@ -49,7 +49,9 @@ public class InputStreamUtils {
 
   static {
     try {
-      getAttribute = Class.forName("io.opentelemetry.sdk.trace.SdkSpan").getDeclaredMethod("getAttribute", AttributeKey.class);
+      getAttribute =
+          Class.forName("io.opentelemetry.sdk.trace.SdkSpan")
+              .getDeclaredMethod("getAttribute", AttributeKey.class);
     } catch (NoSuchMethodException e) {
       log.error("getAttribute method not found in SdkSpan class", e);
     } catch (ClassNotFoundException e) {
@@ -75,10 +77,12 @@ public class InputStreamUtils {
               .setAttribute(attributeKey, value);
 
       // Also add content type if present
-      if (getAttribute != null && span.getClass().getName().equals("io.opentelemetry.sdk.trace.SdkSpan")) {
+      if (getAttribute != null
+          && span.getClass().getName().equals("io.opentelemetry.sdk.trace.SdkSpan")) {
         try {
           Object reqContentType =
-              getAttribute.invoke(span, HypertraceSemanticAttributes.HTTP_REQUEST_HEADER_CONTENT_TYPE);
+              getAttribute.invoke(
+                  span, HypertraceSemanticAttributes.HTTP_REQUEST_HEADER_CONTENT_TYPE);
           if (reqContentType != null) {
             spanBuilder.setAttribute("http.request.header.content-type", (String) reqContentType);
           }

--- a/instrumentation/vertx/vertx-web-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/vertx/ResponseBodyWrappingHandler.java
+++ b/instrumentation/vertx/vertx-web-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/vertx/ResponseBodyWrappingHandler.java
@@ -41,7 +41,9 @@ public class ResponseBodyWrappingHandler implements Handler<Buffer> {
 
   static {
     try {
-      getAttribute = Class.forName("io.opentelemetry.sdk.trace.SdkSpan").getDeclaredMethod("getAttribute", AttributeKey.class);
+      getAttribute =
+          Class.forName("io.opentelemetry.sdk.trace.SdkSpan")
+              .getDeclaredMethod("getAttribute", AttributeKey.class);
     } catch (NoSuchMethodException e) {
       log.error("getAttribute method not found in SdkSpan class", e);
     } catch (ClassNotFoundException e) {
@@ -73,7 +75,8 @@ public class ResponseBodyWrappingHandler implements Handler<Buffer> {
               .setAttribute(HypertraceSemanticAttributes.HTTP_RESPONSE_BODY, responseBody);
 
       // Also add content type if present
-      if (getAttribute != null && span.getClass().getName().equals("io.opentelemetry.sdk.trace.SdkSpan")) {
+      if (getAttribute != null
+          && span.getClass().getName().equals("io.opentelemetry.sdk.trace.SdkSpan")) {
         try {
           Object resContentType =
               getAttribute.invoke(

--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/instrumentation/HypertraceSemanticAttributes.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/instrumentation/HypertraceSemanticAttributes.java
@@ -45,6 +45,12 @@ public class HypertraceSemanticAttributes {
   public static final AttributeKey<String> HTTP_REQUEST_SESSION_ID =
       AttributeKey.stringKey("http.request.session_id");
 
+  public static final AttributeKey<String> HTTP_REQUEST_HEADER_CONTENT_TYPE =
+      AttributeKey.stringKey("http.request.header.content-type");
+
+  public static final AttributeKey<String> HTTP_RESPONSE_HEADER_CONTENT_TYPE =
+      AttributeKey.stringKey("http.response.header.content-type");
+
   public static final AttributeKey<String> RPC_REQUEST_BODY =
       AttributeKey.stringKey("rpc.request.body");
   public static final AttributeKey<String> RPC_RESPONSE_BODY =

--- a/testing-common/src/testFixtures/java/org/hypertrace/agent/testing/AbstractHttpClientTest.java
+++ b/testing-common/src/testFixtures/java/org/hypertrace/agent/testing/AbstractHttpClientTest.java
@@ -16,6 +16,7 @@
 
 package org.hypertrace.agent.testing;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -118,6 +119,10 @@ public abstract class AbstractHttpClientTest extends AbstractInstrumenterTest {
       Assertions.assertEquals(2, traces.get(0).size());
       SpanData responseBodySpan = traces.get(0).get(1);
       assertBodies(clientSpan, responseBodySpan, body, body);
+      Assertions.assertNotNull(
+          responseBodySpan
+              .getAttributes()
+              .get(AttributeKey.stringKey("http.response.header.content-type")));
     } else {
       Assertions.assertEquals(1, traces.get(0).size());
       assertRequestAndResponseBody(clientSpan, body, body);


### PR DESCRIPTION
In case of capturing request/response bodies in additional data spans, we only have the body. Also adding the content type header in those spans along with body. 
