### PR TITLE
Add ht to instrumentation names in tests

### DIFF
--- a/instrumentation/java-streams/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/java/ContextAccessorInstrumentationModule.java
+++ b/instrumentation/java-streams/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/java/ContextAccessorInstrumentationModule.java
@@ -60,7 +60,7 @@ public class ContextAccessorInstrumentationModule extends InstrumentationModule
   }
 
   public ContextAccessorInstrumentationModule() {
-    super("test-context-accessor");
+    super("test-context-accessor", "ht");
   }
 
   @Override

--- a/instrumentation/servlet/servlet-3.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/request/ServletInputStreamContextAccessInstrumentationModule.java
+++ b/instrumentation/servlet/servlet-3.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/request/ServletInputStreamContextAccessInstrumentationModule.java
@@ -41,7 +41,7 @@ public class ServletInputStreamContextAccessInstrumentationModule extends Instru
     implements InstrumentationModuleMuzzle {
 
   public ServletInputStreamContextAccessInstrumentationModule() {
-    super("test-servlet-input-stream");
+    super("test-servlet-input-stream", "ht");
   }
 
   @Override

--- a/instrumentation/servlet/servlet-3.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/response/ServletOutputStreamContextAccessInstrumentationModule.java
+++ b/instrumentation/servlet/servlet-3.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/response/ServletOutputStreamContextAccessInstrumentationModule.java
@@ -40,7 +40,7 @@ public class ServletOutputStreamContextAccessInstrumentationModule extends Instr
     implements InstrumentationModuleMuzzle {
 
   public ServletOutputStreamContextAccessInstrumentationModule() {
-    super("test-servlet-output-stream");
+    super("test-servlet-output-stream", "ht");
   }
 
   @Override

--- a/instrumentation/servlet/servlet-rw/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/rw/reader/BufferedReaderContextAccessInstrumentationModule.java
+++ b/instrumentation/servlet/servlet-rw/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/rw/reader/BufferedReaderContextAccessInstrumentationModule.java
@@ -39,7 +39,7 @@ public class BufferedReaderContextAccessInstrumentationModule extends Instrument
     implements InstrumentationModuleMuzzle {
 
   public BufferedReaderContextAccessInstrumentationModule() {
-    super("test-buffered-reader");
+    super("test-buffered-reader", "ht");
   }
 
   @Override

--- a/instrumentation/servlet/servlet-rw/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/rw/writer/PrintWriterContextAccessInstrumentationModule.java
+++ b/instrumentation/servlet/servlet-rw/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/rw/writer/PrintWriterContextAccessInstrumentationModule.java
@@ -41,7 +41,7 @@ public class PrintWriterContextAccessInstrumentationModule extends Instrumentati
     implements InstrumentationModuleMuzzle {
 
   public PrintWriterContextAccessInstrumentationModule() {
-    super("test-print-writer");
+    super("test-print-writer", "ht");
   }
 
   @Override


### PR DESCRIPTION
Add `ht` to instrumentation modules used in tests to be able to easily enable/disable instrumentation