### PR TITLE
Add hostname to attributes

### DIFF
--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/CgroupsReader.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/CgroupsReader.java
@@ -25,8 +25,7 @@ import org.slf4j.LoggerFactory;
 
 public class CgroupsReader {
 
-  private static final Logger log =
-      LoggerFactory.getLogger(HypertraceResourceProvider.class.getName());
+  private static final Logger log = LoggerFactory.getLogger(CgroupsReader.class.getName());
 
   private static final String DEFAULT_CGROUPS_PATH = "/proc/self/cgroup";
   private static final int CONTAINER_ID_LENGTH = 64;

--- a/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/AddTagsSpanProcessor.java
+++ b/otel-extensions/src/main/java/org/hypertrace/agent/otel/extensions/processor/AddTagsSpanProcessor.java
@@ -23,22 +23,37 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import org.hypertrace.agent.otel.extensions.CgroupsReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AddTagsSpanProcessor implements SpanProcessor {
 
+  private static final Logger log = LoggerFactory.getLogger(AddTagsSpanProcessor.class.getName());
+
   // initialize at startup because the processor is executed for every span.
-  private String containerId;
+  private final String containerId;
+  private final String hostName;
 
   /** Note - the container id is not available using this technique if cgroup2 is installed. */
   public AddTagsSpanProcessor() {
     CgroupsReader cgroupsReader = new CgroupsReader();
     containerId = cgroupsReader.readContainerId();
+    String hostnameEnv = "";
+    try {
+      hostnameEnv = System.getenv("HOSTNAME");
+    } catch (SecurityException e) {
+      log.error("could not get hostname", e);
+    }
+    hostName = hostnameEnv;
   }
 
   @Override
   public void onStart(Context parentContext, ReadWriteSpan span) {
     if (containerId != null && !containerId.isEmpty()) {
       span.setAttribute(ResourceAttributes.CONTAINER_ID, containerId);
+    }
+    if (hostName != null && !hostName.isEmpty()) {
+      span.setAttribute(ResourceAttributes.HOST_NAME, hostName);
     }
   }
 


### PR DESCRIPTION
Along with container id, it is useful to have hostname to directly know the pod from which a span came.