### PR TITLE
Custom block code and msg

### DIFF
--- a/filter-api/src/main/java/org/hypertrace/agent/filter/MultiFilter.java
+++ b/filter-api/src/main/java/org/hypertrace/agent/filter/MultiFilter.java
@@ -49,7 +49,7 @@ class MultiFilter implements Filter {
             t);
       }
     }
-    return new FilterResult(false, 403, "Hypertrace Blocked Request");
+    return new FilterResult(false, 0, "");
   }
 
   @Override
@@ -67,6 +67,6 @@ class MultiFilter implements Filter {
             t);
       }
     }
-    return new FilterResult(false, 403, "Hypertrace Blocked Request");
+    return new FilterResult(false, 0, "");
   }
 }

--- a/filter-api/src/main/java/org/hypertrace/agent/filter/api/Filter.java
+++ b/filter-api/src/main/java/org/hypertrace/agent/filter/api/Filter.java
@@ -18,6 +18,7 @@ package org.hypertrace.agent.filter.api;
 
 import io.opentelemetry.api.trace.Span;
 import java.util.Map;
+import org.hypertrace.agent.core.filter.FilterResult;
 import org.hypertrace.agent.filter.FilterRegistry;
 
 /**
@@ -32,7 +33,7 @@ public interface Filter {
    * @param headers are used for blocking evaluation.
    * @return filter result
    */
-  boolean evaluateRequestHeaders(Span span, Map<String, String> headers);
+  FilterResult evaluateRequestHeaders(Span span, Map<String, String> headers);
 
   /**
    * Evaluate the execution.
@@ -42,5 +43,5 @@ public interface Filter {
    * @param headers of the request associated with this body
    * @return filter result
    */
-  boolean evaluateRequestBody(Span span, String body, Map<String, String> headers);
+  FilterResult evaluateRequestBody(Span span, String body, Map<String, String> headers);
 }

--- a/instrumentation/grpc-1.6/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/grpc/v1_6/server/GrpcServerInterceptor.java
+++ b/instrumentation/grpc-1.6/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/grpc/v1_6/server/GrpcServerInterceptor.java
@@ -59,6 +59,7 @@ public class GrpcServerInterceptor implements ServerInterceptor {
 
       boolean block = FilterRegistry.getFilter().evaluateRequestHeaders(currentSpan, mapHeaders);
       if (block) {
+        // TODO Status.PERMISSION_DENIED.withDescription("")
         call.close(Status.PERMISSION_DENIED, new Metadata());
         @SuppressWarnings("unchecked")
         ServerCall.Listener<ReqT> noop = NoopServerCallListener.INSTANCE;

--- a/instrumentation/grpc-1.6/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/grpc/v1_6/server/GrpcServerInterceptor.java
+++ b/instrumentation/grpc-1.6/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/grpc/v1_6/server/GrpcServerInterceptor.java
@@ -61,6 +61,8 @@ public class GrpcServerInterceptor implements ServerInterceptor {
       FilterResult filterResult =
           FilterRegistry.getFilter().evaluateRequestHeaders(currentSpan, mapHeaders);
       if (filterResult.shouldBlock()) {
+        // We cannot send custom message in grpc calls, so added the Status message as the blocking
+        // message
         // TODO: map http codes with grpc codes. filterResult.getBlockingStatusCode()
         call.close(
             Status.PERMISSION_DENIED.withDescription(filterResult.getBlockingMsg()),

--- a/instrumentation/grpc-1.6/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/grpc/v1_6/server/GrpcServerInterceptor.java
+++ b/instrumentation/grpc-1.6/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/grpc/v1_6/server/GrpcServerInterceptor.java
@@ -61,12 +61,9 @@ public class GrpcServerInterceptor implements ServerInterceptor {
       FilterResult filterResult =
           FilterRegistry.getFilter().evaluateRequestHeaders(currentSpan, mapHeaders);
       if (filterResult.shouldBlock()) {
-        // We cannot send custom message in grpc calls, so added the Status message as the blocking
-        // message
+        // We cannot send custom message in grpc calls
         // TODO: map http codes with grpc codes. filterResult.getBlockingStatusCode()
-        call.close(
-            Status.PERMISSION_DENIED.withDescription(filterResult.getBlockingMsg()),
-            new Metadata());
+        call.close(Status.PERMISSION_DENIED, new Metadata());
         @SuppressWarnings("unchecked")
         ServerCall.Listener<ReqT> noop = NoopServerCallListener.INSTANCE;
         return noop;

--- a/instrumentation/grpc-1.6/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/grpc/v1_6/GrpcInstrumentationTest.java
+++ b/instrumentation/grpc-1.6/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/grpc/v1_6/GrpcInstrumentationTest.java
@@ -159,7 +159,8 @@ public class GrpcInstrumentationTest extends AbstractInstrumenterTest {
     try {
       Response response = blockingStub.sayHello(REQUEST);
     } catch (StatusRuntimeException ex) {
-      Assertions.assertEquals(Status.PERMISSION_DENIED, ex.getStatus());
+      Assertions.assertEquals(Status.PERMISSION_DENIED.getCode(), ex.getStatus().getCode());
+      Assertions.assertEquals("Hypertrace Blocked Request", ex.getStatus().getDescription());
     }
 
     TEST_WRITER.waitForSpans(2);

--- a/instrumentation/grpc-1.6/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/grpc/v1_6/GrpcInstrumentationTest.java
+++ b/instrumentation/grpc-1.6/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/grpc/v1_6/GrpcInstrumentationTest.java
@@ -160,7 +160,6 @@ public class GrpcInstrumentationTest extends AbstractInstrumenterTest {
       Response response = blockingStub.sayHello(REQUEST);
     } catch (StatusRuntimeException ex) {
       Assertions.assertEquals(Status.PERMISSION_DENIED.getCode(), ex.getStatus().getCode());
-      Assertions.assertEquals("Hypertrace Blocked Request", ex.getStatus().getDescription());
     }
 
     TEST_WRITER.waitForSpans(2);

--- a/instrumentation/micronaut-1.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/micronaut/MicronautInstrumentationTest.java
+++ b/instrumentation/micronaut-1.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/micronaut/MicronautInstrumentationTest.java
@@ -175,7 +175,7 @@ public class MicronautInstrumentationTest extends AbstractInstrumenterTest {
 
     try (Response response = httpClient.newCall(request).execute()) {
       Assertions.assertEquals(403, response.code());
-      Assertions.assertTrue(response.body().string().isEmpty());
+      Assertions.assertEquals("Hypertrace Blocked Request", response.body().string());
     }
 
     List<List<SpanData>> traces = TEST_WRITER.getTraces();

--- a/instrumentation/micronaut-3.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/micronaut/v3/MicronautInstrumentationTest.java
+++ b/instrumentation/micronaut-3.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/micronaut/v3/MicronautInstrumentationTest.java
@@ -175,7 +175,7 @@ public class MicronautInstrumentationTest extends AbstractInstrumenterTest {
 
     try (Response response = httpClient.newCall(request).execute()) {
       Assertions.assertEquals(403, response.code());
-      Assertions.assertTrue(response.body().string().isEmpty());
+      Assertions.assertEquals("Hypertrace Blocked Request", response.body().string());
     }
 
     List<List<SpanData>> traces = TEST_WRITER.getTraces();

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/server/HttpServerBlockingRequestHandler.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/server/HttpServerBlockingRequestHandler.java
@@ -69,6 +69,7 @@ public class HttpServerBlockingRequestHandler extends ChannelInboundHandlerAdapt
   }
 
   static void forbidden(ChannelHandlerContext ctx, HttpRequest request) {
+    // TODO
     DefaultFullHttpResponse blockResponse =
         new DefaultFullHttpResponse(request.getProtocolVersion(), HttpResponseStatus.FORBIDDEN);
     blockResponse.headers().add("Content-Length", "0");

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/server/HttpServerBlockingRequestHandler.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/server/HttpServerBlockingRequestHandler.java
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.javaagent.instrumentation.hypertrace.netty.v4_0.server;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -30,6 +31,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.netty.v4_0.AttributeKeys;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.hypertrace.agent.core.filter.FilterResult;
 import org.hypertrace.agent.filter.FilterRegistry;
@@ -79,8 +81,11 @@ public class HttpServerBlockingRequestHandler extends ChannelInboundHandlerAdapt
         new DefaultFullHttpResponse(
             request.getProtocolVersion(),
             new HttpResponseStatus(
-                filterResult.getBlockingStatusCode(), filterResult.getBlockingMsg()));
-    blockResponse.headers().add("Content-Length", "0");
+                filterResult.getBlockingStatusCode(), HttpResponseStatus.FORBIDDEN.reasonPhrase()),
+            Unpooled.copiedBuffer(filterResult.getBlockingMsg().getBytes(StandardCharsets.UTF_8)));
+    blockResponse
+        .headers()
+        .add("Content-Length", String.valueOf(filterResult.getBlockingMsg().length()));
     ReferenceCountUtil.release(request);
     ctx.writeAndFlush(blockResponse).addListener(ChannelFutureListener.CLOSE);
   }

--- a/instrumentation/netty/netty-4.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/server/AbstractNetty40ServerInstrumentationTest.java
+++ b/instrumentation/netty/netty-4.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/server/AbstractNetty40ServerInstrumentationTest.java
@@ -260,7 +260,7 @@ public abstract class AbstractNetty40ServerInstrumentationTest extends AbstractI
 
     try (Response response = httpClient.newCall(request2).execute()) {
       Assertions.assertEquals(403, response.code());
-      Assertions.assertTrue(response.body().string().isEmpty());
+      Assertions.assertEquals("Hypertrace Blocked Request", response.body().string());
     }
 
     List<List<SpanData>> traces2 = TEST_WRITER.getTraces();

--- a/instrumentation/netty/netty-4.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/server/AbstractNetty40ServerInstrumentationTest.java
+++ b/instrumentation/netty/netty-4.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_0/server/AbstractNetty40ServerInstrumentationTest.java
@@ -148,7 +148,7 @@ public abstract class AbstractNetty40ServerInstrumentationTest extends AbstractI
 
     try (Response response = httpClient.newCall(request).execute()) {
       Assertions.assertEquals(403, response.code());
-      Assertions.assertTrue(response.body().string().isEmpty());
+      Assertions.assertEquals("Hypertrace Blocked Request", response.body().string());
     }
 
     List<List<SpanData>> traces = TEST_WRITER.getTraces();
@@ -168,9 +168,7 @@ public abstract class AbstractNetty40ServerInstrumentationTest extends AbstractI
             .getAttributes()
             .get(HypertraceSemanticAttributes.httpResponseHeader(RESPONSE_HEADER_NAME)));
     Assertions.assertNull(
-        spanData
-            .getAttributes()
-            .get(HypertraceSemanticAttributes.httpResponseHeader(RESPONSE_BODY)));
+        spanData.getAttributes().get(HypertraceSemanticAttributes.HTTP_RESPONSE_BODY));
 
     RequestBody requestBody = blockedRequestBody(true, 3000, 75);
     Request request2 =
@@ -182,7 +180,7 @@ public abstract class AbstractNetty40ServerInstrumentationTest extends AbstractI
 
     try (Response response = httpClient.newCall(request2).execute()) {
       Assertions.assertEquals(403, response.code());
-      Assertions.assertTrue(response.body().string().isEmpty());
+      Assertions.assertEquals("Hypertrace Blocked Request", response.body().string());
     }
 
     List<List<SpanData>> traces2 = TEST_WRITER.getTraces();
@@ -202,9 +200,7 @@ public abstract class AbstractNetty40ServerInstrumentationTest extends AbstractI
             .getAttributes()
             .get(HypertraceSemanticAttributes.httpResponseHeader(RESPONSE_HEADER_NAME)));
     Assertions.assertNull(
-        spanData2
-            .getAttributes()
-            .get(HypertraceSemanticAttributes.httpResponseHeader(RESPONSE_BODY)));
+        spanData2.getAttributes().get(HypertraceSemanticAttributes.HTTP_RESPONSE_BODY));
   }
 
   @Test

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerBlockingRequestHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerBlockingRequestHandler.java
@@ -68,6 +68,7 @@ public class HttpServerBlockingRequestHandler extends ChannelInboundHandlerAdapt
   }
 
   static void forbidden(ChannelHandlerContext ctx, HttpRequest request) {
+    // TODO
     DefaultFullHttpResponse blockResponse =
         new DefaultFullHttpResponse(request.protocolVersion(), HttpResponseStatus.FORBIDDEN);
     blockResponse.headers().add("Content-Length", "0");

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerBlockingRequestHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/HttpServerBlockingRequestHandler.java
@@ -31,6 +31,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.netty.v4.common.HttpRequestAndChannel;
 import io.opentelemetry.javaagent.instrumentation.hypertrace.netty.v4_1.AttributeKeys;
 import java.util.Map;
+import org.hypertrace.agent.core.filter.FilterResult;
 import org.hypertrace.agent.filter.FilterRegistry;
 
 public class HttpServerBlockingRequestHandler extends ChannelInboundHandlerAdapter {
@@ -51,26 +52,33 @@ public class HttpServerBlockingRequestHandler extends ChannelInboundHandlerAdapt
     if (msg instanceof HttpRequest) {
       Attribute<Map<String, String>> headersAttr = channel.attr(AttributeKeys.REQUEST_HEADERS);
       Map<String, String> headers = headersAttr.getAndRemove();
-      if (headers != null && FilterRegistry.getFilter().evaluateRequestHeaders(span, headers)) {
-        forbidden(ctx, (HttpRequest) msg);
-        return;
+      if (headers != null) {
+        FilterResult filterResult =
+            FilterRegistry.getFilter().evaluateRequestHeaders(span, headers);
+        if (filterResult.shouldBlock()) {
+          forbidden(ctx, (HttpRequest) msg, filterResult);
+          return;
+        }
       }
     }
     if (msg instanceof HttpContent) {
-      if (FilterRegistry.getFilter().evaluateRequestBody(span, null, null)) {
+      FilterResult filterResult = FilterRegistry.getFilter().evaluateRequestBody(span, null, null);
+      if (filterResult.shouldBlock()) {
         Attribute<?> requestAttr = channel.attr(AttributeKeys.REQUEST);
         HttpRequest req = ((HttpRequestAndChannel) (requestAttr.get())).request();
-        forbidden(ctx, req);
+        forbidden(ctx, req, filterResult);
         return;
       }
     }
     ctx.fireChannelRead(msg);
   }
 
-  static void forbidden(ChannelHandlerContext ctx, HttpRequest request) {
-    // TODO
+  static void forbidden(ChannelHandlerContext ctx, HttpRequest request, FilterResult filterResult) {
     DefaultFullHttpResponse blockResponse =
-        new DefaultFullHttpResponse(request.protocolVersion(), HttpResponseStatus.FORBIDDEN);
+        new DefaultFullHttpResponse(
+            request.protocolVersion(),
+            new HttpResponseStatus(
+                filterResult.getBlockingStatusCode(), filterResult.getBlockingMsg()));
     blockResponse.headers().add("Content-Length", "0");
     ReferenceCountUtil.release(request);
     ctx.writeAndFlush(blockResponse).addListener(ChannelFutureListener.CLOSE);

--- a/instrumentation/netty/netty-4.1/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/AbstractNetty41ServerInstrumentationTest.java
+++ b/instrumentation/netty/netty-4.1/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/AbstractNetty41ServerInstrumentationTest.java
@@ -148,7 +148,7 @@ public abstract class AbstractNetty41ServerInstrumentationTest extends AbstractI
 
     try (Response response = httpClient.newCall(request).execute()) {
       Assertions.assertEquals(403, response.code());
-      Assertions.assertTrue(response.body().string().isEmpty());
+      Assertions.assertEquals("Hypertrace Blocked Request", response.body().string());
     }
 
     List<List<SpanData>> traces = TEST_WRITER.getTraces();
@@ -168,9 +168,7 @@ public abstract class AbstractNetty41ServerInstrumentationTest extends AbstractI
             .getAttributes()
             .get(HypertraceSemanticAttributes.httpResponseHeader(RESPONSE_HEADER_NAME)));
     Assertions.assertNull(
-        spanData
-            .getAttributes()
-            .get(HypertraceSemanticAttributes.httpResponseHeader(RESPONSE_BODY)));
+        spanData.getAttributes().get(HypertraceSemanticAttributes.HTTP_RESPONSE_BODY));
 
     RequestBody requestBody = blockedRequestBody(true, 3000, 75);
     Request request2 =
@@ -182,7 +180,7 @@ public abstract class AbstractNetty41ServerInstrumentationTest extends AbstractI
 
     try (Response response = httpClient.newCall(request2).execute()) {
       Assertions.assertEquals(403, response.code());
-      Assertions.assertTrue(response.body().string().isEmpty());
+      Assertions.assertEquals("Hypertrace Blocked Request", response.body().string());
     }
 
     List<List<SpanData>> traces2 = TEST_WRITER.getTraces();
@@ -202,9 +200,7 @@ public abstract class AbstractNetty41ServerInstrumentationTest extends AbstractI
             .getAttributes()
             .get(HypertraceSemanticAttributes.httpResponseHeader(RESPONSE_HEADER_NAME)));
     Assertions.assertNull(
-        spanData2
-            .getAttributes()
-            .get(HypertraceSemanticAttributes.httpResponseHeader(RESPONSE_BODY)));
+        spanData2.getAttributes().get(HypertraceSemanticAttributes.HTTP_RESPONSE_BODY));
   }
 
   @Test

--- a/instrumentation/netty/netty-4.1/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/AbstractNetty41ServerInstrumentationTest.java
+++ b/instrumentation/netty/netty-4.1/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/netty/v4_1/server/AbstractNetty41ServerInstrumentationTest.java
@@ -260,7 +260,7 @@ public abstract class AbstractNetty41ServerInstrumentationTest extends AbstractI
 
     try (Response response = httpClient.newCall(request2).execute()) {
       Assertions.assertEquals(403, response.code());
-      Assertions.assertTrue(response.body().string().isEmpty());
+      Assertions.assertEquals("Hypertrace Blocked Request", response.body().string());
     }
 
     List<List<SpanData>> traces2 = TEST_WRITER.getTraces();

--- a/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet30AndFilterInstrumentation.java
+++ b/instrumentation/servlet/servlet-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet30AndFilterInstrumentation.java
@@ -116,6 +116,12 @@ public class Servlet30AndFilterInstrumentation implements TypeInstrumentation {
       }
 
       if (FilterRegistry.getFilter().evaluateRequestHeaders(currentSpan, headers)) {
+        // TODO
+        // String responseToClient= "<tdcp><cmd><ack cmd=”Init”><panelistid>3849303</panelistid></ack></cmd></tdcp>";
+        //
+        //httpServletResponse.setStatus(HttpServletResponse.SC_OK);
+        //httpServletResponse.getWriter().write(responseToClient);
+        //httpServletResponse.getWriter().flush();
         httpResponse.setStatus(403);
         // skip execution of the user code
         return true;
@@ -208,6 +214,12 @@ public class Servlet30AndFilterInstrumentation implements TypeInstrumentation {
         Throwable tmp = throwable;
         while (tmp != null) { // loop in case our exception is nested (eg. springframework)
           if (tmp instanceof HypertraceEvaluationException) {
+            // TODO
+            //String responseToClient= "<tdcp><cmd><ack cmd=”Init”><panelistid>3849303</panelistid></ack></cmd></tdcp>";
+            //
+            //httpServletResponse.setStatus(HttpServletResponse.SC_OK);
+            //httpServletResponse.getWriter().write(responseToClient);
+            //httpServletResponse.getWriter().flush();
             httpResponse.setStatus(403);
             // bytebuddy treats the reassignment of this variable to null as an instruction to
             // suppress this exception, which is what we want

--- a/instrumentation/servlet/servlet-3.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet30InstrumentationTest.java
+++ b/instrumentation/servlet/servlet-3.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/Servlet30InstrumentationTest.java
@@ -278,6 +278,7 @@ public class Servlet30InstrumentationTest extends AbstractInstrumenterTest {
             .build();
     try (Response response = httpClient.newCall(request).execute()) {
       Assertions.assertEquals(403, response.code());
+      Assertions.assertEquals("Hypertrace Blocked Request", response.body().string());
     }
 
     TEST_WRITER.waitForTraces(1);
@@ -307,6 +308,7 @@ public class Servlet30InstrumentationTest extends AbstractInstrumenterTest {
             .build();
     try (Response response = httpClient.newCall(request).execute()) {
       Assertions.assertEquals(403, response.code());
+      Assertions.assertEquals("Hypertrace Blocked Request", response.body().string());
     }
 
     TEST_WRITER.waitForTraces(1);
@@ -336,6 +338,7 @@ public class Servlet30InstrumentationTest extends AbstractInstrumenterTest {
             .build();
     try (Response response = httpClient.newCall(request).execute()) {
       Assertions.assertEquals(403, response.code());
+      Assertions.assertEquals("Hypertrace Blocked Request", response.body().string());
     }
 
     TEST_WRITER.waitForTraces(1);

--- a/instrumentation/servlet/servlet-3.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/request/ServletInputStreamInstrumentationTest.java
+++ b/instrumentation/servlet/servlet-3.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/v3_0/nowrapping/request/ServletInputStreamInstrumentationTest.java
@@ -26,6 +26,7 @@ import javax.servlet.ServletInputStream;
 import org.ServletStreamContextAccess;
 import org.TestServletInputStream;
 import org.hypertrace.agent.core.TriFunction;
+import org.hypertrace.agent.core.filter.FilterResult;
 import org.hypertrace.agent.core.instrumentation.buffer.BoundedBuffersFactory;
 import org.hypertrace.agent.core.instrumentation.buffer.BoundedByteArrayOutputStream;
 import org.hypertrace.agent.core.instrumentation.buffer.ByteBufferSpanPair;
@@ -91,6 +92,6 @@ public class ServletInputStreamInstrumentationTest extends AbstractInstrumenterT
     Assertions.assertEquals(BODY.substring(2), buffer.toStringWithSuppliedCharset());
   }
 
-  private static final TriFunction<Span, String, Map<String, String>, Boolean> NOOP_FILTER =
-      (span, body, headers) -> false;
+  private static final TriFunction<Span, String, Map<String, String>, FilterResult> NOOP_FILTER =
+      (span, body, headers) -> new FilterResult(false, 0, "");
 }

--- a/instrumentation/servlet/servlet-rw/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/rw/reader/BufferedReaderInstrumentationTest.java
+++ b/instrumentation/servlet/servlet-rw/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/servlet/rw/reader/BufferedReaderInstrumentationTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.BufferedReaderPrintWriterContextAccess;
 import org.TestBufferedReader;
 import org.hypertrace.agent.core.TriFunction;
+import org.hypertrace.agent.core.filter.FilterResult;
 import org.hypertrace.agent.core.instrumentation.buffer.*;
 import org.hypertrace.agent.testing.AbstractInstrumenterTest;
 import org.junit.jupiter.api.Assertions;
@@ -34,8 +35,8 @@ public class BufferedReaderInstrumentationTest extends AbstractInstrumenterTest 
 
   private static final String TEST_SPAN_NAME = "foo";
   private static final String BODY = "boobar";
-  private static final TriFunction<Span, String, Map<String, String>, Boolean> NOOP_FILTER =
-      (span, s, stringStringMap) -> false;
+  private static final TriFunction<Span, String, Map<String, String>, FilterResult> NOOP_FILTER =
+      (span, s, stringStringMap) -> new FilterResult(false, 0, "");
 
   @Test
   public void read() throws IOException {

--- a/instrumentation/spring/spring-webflux-5.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/spring/webflux/SpringWebfluxServerTest.java
+++ b/instrumentation/spring/spring-webflux-5.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/spring/webflux/SpringWebfluxServerTest.java
@@ -187,7 +187,7 @@ public class SpringWebfluxServerTest extends AbstractInstrumenterTest {
 
     try (Response response = httpClient.newCall(request).execute()) {
       Assertions.assertEquals(403, response.code());
-      Assertions.assertTrue(response.body().string().isEmpty());
+      Assertions.assertEquals("Hypertrace Blocked Request", response.body().string());
     }
 
     List<List<SpanData>> traces = TEST_WRITER.getTraces();

--- a/instrumentation/vertx/vertx-web-3.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/vertx/VertxServerInstrumentationTest.java
+++ b/instrumentation/vertx/vertx-web-3.0/src/test/java/io/opentelemetry/javaagent/instrumentation/hypertrace/vertx/VertxServerInstrumentationTest.java
@@ -144,7 +144,7 @@ class VertxServerInstrumentationTest extends AbstractInstrumenterTest {
 
     try (Response response = httpClient.newCall(request).execute()) {
       Assertions.assertEquals(403, response.code());
-      Assertions.assertTrue(response.body().string().isEmpty());
+      Assertions.assertEquals("Hypertrace Blocked Request", response.body().string());
     }
 
     List<List<SpanData>> traces = TEST_WRITER.getTraces();

--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/filter/FilterResult.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/filter/FilterResult.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The Hypertrace Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hypertrace.agent.core.filter;
+
+public class FilterResult {
+
+  private final boolean shouldBlock;
+  private final int blockingStatusCode;
+  private final String blockingMsg;
+
+  public FilterResult(boolean shouldBlock, int blockingStatusCode, String blockingMsg) {
+    this.shouldBlock = shouldBlock;
+    this.blockingStatusCode = blockingStatusCode;
+    this.blockingMsg = blockingMsg;
+  }
+
+  public boolean shouldBlock() {
+    return shouldBlock;
+  }
+
+  public int getBlockingStatusCode() {
+    return blockingStatusCode;
+  }
+
+  public String getBlockingMsg() {
+    return blockingMsg;
+  }
+}

--- a/javaagent-core/src/main/java/org/hypertrace/agent/core/instrumentation/HypertraceEvaluationException.java
+++ b/javaagent-core/src/main/java/org/hypertrace/agent/core/instrumentation/HypertraceEvaluationException.java
@@ -16,6 +16,8 @@
 
 package org.hypertrace.agent.core.instrumentation;
 
+import org.hypertrace.agent.core.filter.FilterResult;
+
 /**
  * A custom exception used to terminate the handling of a request thread after the initial
  * opportunity for middleware to look at the contents of an HTTP request and determine if it should
@@ -34,7 +36,14 @@ public final class HypertraceEvaluationException extends RuntimeException {
   private static final String DEFAULT_MESSAGE =
       "A filter implementation determined that this request should be blocked";
 
-  public HypertraceEvaluationException() {
+  private final FilterResult filterResult;
+
+  public HypertraceEvaluationException(FilterResult filterResult) {
     super(DEFAULT_MESSAGE);
+    this.filterResult = filterResult;
+  }
+
+  public FilterResult getFilterResult() {
+    return filterResult;
   }
 }


### PR DESCRIPTION
Adding a FilterResult in the Filter API, so that filters can provide custom blocking status code and message along with the FilterResult. 
Using this FilterResult to block and set the response status and message accordingly