### PR TITLE
ENG-46119: fix response charset and adding support for gzip compression

### DIFF
--- a/instrumentation/okhttp/okhttp-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/okhttp/v3_0/OkHttpTracingInterceptor.java
+++ b/instrumentation/okhttp/okhttp-3.0/src/main/java/io/opentelemetry/javaagent/instrumentation/hypertrace/okhttp/v3_0/OkHttpTracingInterceptor.java
@@ -19,6 +19,8 @@ package io.opentelemetry.javaagent.instrumentation.hypertrace.okhttp.v3_0;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 import okhttp3.Headers;
 import okhttp3.Interceptor;
@@ -28,6 +30,9 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okio.Buffer;
+import okio.BufferedSource;
+import okio.GzipSource;
+import okio.Okio;
 import org.hypertrace.agent.core.config.InstrumentationConfig;
 import org.hypertrace.agent.core.instrumentation.HypertraceSemanticAttributes;
 import org.hypertrace.agent.core.instrumentation.utils.ContentTypeUtils;
@@ -88,6 +93,7 @@ public class OkHttpTracingInterceptor implements Interceptor {
     if (response.body() == null) {
       return response;
     }
+
     ResponseBody responseBody = response.body();
     MediaType mediaType = responseBody.contentType();
     if (mediaType == null || !ContentTypeUtils.shouldCapture(mediaType.toString())) {
@@ -95,17 +101,48 @@ public class OkHttpTracingInterceptor implements Interceptor {
     }
 
     try {
-      String body = responseBody.string();
+      // Read the entire response body one-shot into a byte-array
+      // responseBody.string(), this looks for the charset if available in content-type header
+      // else defaults to utf-8. So read bytes itself as done here and use when building new response
+      // ref: https://square.github.io/okhttp/3.x/okhttp/okhttp3/ResponseBody.html
+      byte[] byteArray = responseBody.source().readByteArray();
+      String body;
+
+      // Determine the content encoding
+      String contentEncoding = response.header("Content-Encoding");
+      if (contentEncoding != null && contentEncoding.toLowerCase().contains("gzip")) {
+        // Decompress the response body if it is GZIP encoded using GzipSource
+        GzipSource gzipSource = new GzipSource(new Buffer().write(byteArray));
+        BufferedSource bufferedGzipSource = Okio.buffer(gzipSource);
+
+        // capture the decompressed content from gzip source to set as response body in span
+        body = bufferedGzipSource.readString(getCharset(mediaType));
+      } else {
+        // capture the response body for other cases
+        body = new String(byteArray, getCharset(mediaType));
+      }
+
       span.setAttribute(HypertraceSemanticAttributes.HTTP_RESPONSE_BODY, body);
-      return response
-          .newBuilder()
-          .body(ResponseBody.create(responseBody.contentType(), body))
-          .build();
+
+      // Return the response with its body and encoding exactly the same as the original response
+      return response.newBuilder()
+              .body(ResponseBody.create(mediaType, byteArray))
+              .build();
     } catch (IOException e) {
       log.error("Could not read response body", e);
     }
+
     return response;
   }
+
+  // Helper method to determine charset from MediaType if available else default to UTF-8
+  private static Charset getCharset(MediaType mediaType) {
+    if (mediaType != null && mediaType.charset() != null) {
+      return mediaType.charset();
+    }
+    return StandardCharsets.UTF_8; // Default charset
+  }
+
 
   private static void captureHeaders(
       Span span, Headers headers, Function<String, AttributeKey<String>> headerNameProvider) {


### PR DESCRIPTION
## Description
In OkHTTP Tracing interceptor, while capturing response body it is trying to attempt `response().body().string()`, the behaviour of string() function for non-BOM response is, if the response has a Content-Type header that specifies a charset, that is used else defaults to utf-8.  For cases when original response is encoded in `gzip` this causes response parsing failure as the response that interceptor returns is one with modified type/charset. 
`Caused by: java.io.IOException: ID1ID2: actual 0x00001fef != expected 0x00001f8b
	at okio.GzipSource.checkEqual(GzipSource.kt:197)
	at okio.GzipSource.consumeHeader(GzipSource.kt:110)
	at okio.GzipSource.read(GzipSource.kt:62)
	at okio.RealBufferedSource.select(RealBufferedSource.kt:232)
	at okhttp3.internal.Util.readBomAsCharset(Util.kt:265)
	at okhttp3.ResponseBody.string(ResponseBody.kt:187)
	at com.auth0.net.CustomRequest.readResponseBody(CustomRequest.java:58)
	at com.auth0.net.ExtendedBaseRequest.parseResponse(ExtendedBaseRequest.java:70)
	... 2 more
`
ref: https://square.github.io/okhttp/3.x/okhttp/okhttp3/ResponseBody.html
Other issue, is that in case of gzip encoded response, we need to decompress it read response in order to set as span attribute correctly.
### Testing
Verified with response being of type gzip encoded and application/json.
Verified for non-utf8 parsing

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
