### PR TITLE
feat: using latest ubuntu runners

### DIFF
--- a/.github/workflows/build-springboot-smoke-dist.yml
+++ b/.github/workflows/build-springboot-smoke-dist.yml
@@ -42,3 +42,5 @@ jobs:
           ./gradlew jib -PtargetJDK=11 -Djib.httpTimeout=120000 -Djib.console=plain --stacktrace -Ptag=$TAG
           ./gradlew jib -PtargetJDK=15 -Djib.httpTimeout=120000 -Djib.console=plain --stacktrace -Ptag=$TAG
         working-directory: smoke-tests/springboot
+        env:
+          JVM_OPTS: -Xmx1g --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED

--- a/.github/workflows/build-test-matrix.yaml
+++ b/.github/workflows/build-test-matrix.yaml
@@ -14,8 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11 for running Gradle
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: adopt
           java-version: 11
 
       - name: Cache gradle dependencies
@@ -35,3 +36,5 @@ jobs:
           echo "Using extra tag $TAG"
           ./gradlew buildMatrix pushMatrix -PextraTag=$TAG
         working-directory: smoke-tests/matrix
+        env:
+          JVM_OPTS: -Xmx1g --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,12 @@ jobs:
           fetch-depth: 0
           submodules: true
 
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
       - name: create checksum file
         uses: hypertrace/github-actions/checksum@main
 
@@ -37,7 +43,7 @@ jobs:
       - name: build
         run: make build
         env:
-          JVM_OPTS: -Xmx1g
+          JVM_OPTS: -Xmx1g --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED
           TERM: dumb
   muzzle:
     runs-on: ubuntu-latest
@@ -49,6 +55,12 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
           submodules: true
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
 
       - name: create checksum file
         uses: hypertrace/github-actions/checksum@main
@@ -66,7 +78,7 @@ jobs:
       - name: muzzle
         run: make muzzle
         env:
-          JVM_OPTS: -Xmx1g
+          JVM_OPTS: -Xmx1g --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED
           TERM: dumb
 
 #TODO

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
       - name: Check out code
@@ -40,7 +40,7 @@ jobs:
           JVM_OPTS: -Xmx1g
           TERM: dumb
   muzzle:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2.3.4
@@ -71,7 +71,7 @@ jobs:
 
 #TODO
 #  dependency-check:
-#    runs-on: ubuntu-20.04
+#    runs-on: ubuntu-latest
 #    steps:
 #      - name: Check out code
 #        uses: actions/checkout@v2.3.4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
       - name: Check out code
@@ -34,7 +34,7 @@ jobs:
           TERM: dumb
 
   smoke-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         suite: [ "glassfish", "jetty", "liberty", "tomcat", "tomee", "wildfly", "other" ]
@@ -68,7 +68,7 @@ jobs:
 
   release:
     needs: [ test, smoke-test ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Set fetch-depth: 0 to fetch commit history and tags for use in version calculation
       - name: Check out code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,12 @@ jobs:
           fetch-depth: 0
           submodules: true
 
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
       - name: create checksum file
         uses: hypertrace/github-actions/checksum@main
 
@@ -30,7 +36,7 @@ jobs:
       - name: build
         run: make build
         env:
-          JVM_OPTS: -Xmx1g
+          JVM_OPTS: -Xmx1g --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED
           TERM: dumb
 
   smoke-test:
@@ -46,6 +52,12 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
 
       - name: create checksum file
         uses: hypertrace/github-actions/checksum@main
@@ -63,7 +75,7 @@ jobs:
       - name: smoke-test
         run: make smoke-test SMOKE_TEST_SUITE=${{ matrix.suite }}
         env:
-          JVM_OPTS: -Xmx1g
+          JVM_OPTS: -Xmx1g --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED
           TERM: dumb
 
   release:
@@ -76,6 +88,12 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
 
       - name: create checksum file
         uses: hypertrace/github-actions/checksum@main
@@ -96,7 +114,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey=$(echo $SIGNING_KEY | base64 -d) ./gradlew publish
           ./gradlew closeAndReleaseRepository
         env:
-          JVM_OPTS: -Xmx1g
+          JVM_OPTS: -Xmx1g --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED
           TERM: dumb
           ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.ORG_GRADLE_PROJECT_OSSRHUSERNAME }}
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.ORG_GRADLE_PROJECT_OSSRHPASSWORD }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   smoke-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy: 
       matrix:
         suite: [ "glassfish", "jetty", "liberty", "tomcat", "tomee", "wildfly", "other" ]

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -25,6 +25,12 @@ jobs:
           fetch-depth: 0
           submodules: true
 
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
       - name: create checksum file
         uses: hypertrace/github-actions/checksum@main
 
@@ -41,5 +47,5 @@ jobs:
       - name: smoke-test
         run: make smoke-test SMOKE_TEST_SUITE=${{ matrix.suite }}
         env: 
-          JVM_OPTS: -Xmx1g
+          JVM_OPTS: -Xmx1g --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED
           TERM: dumb


### PR DESCRIPTION
Description: 
Ubuntu 20.04 Actions runner image is deprecated as of 15th April 2025. So updating to use ubuntu-latest image
Ref: https://github.com/actions/runner-images/issues/11101
SInce latest ubuntu image uses java 17 by default, updated to use JDK 11 to build and test to keep things as it is