### PR TITLE
chore: Bump opentelemetry jackson version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,8 @@ subprojects {
 
         "opentelemetry_gradle_plugin" to "1.33.0-alpha",
         "byte_buddy" to "1.12.10",
-        "slf4j" to "2.0.7"
+        "slf4j" to "2.0.7",
+        "jackson" to "2.18.9"
     ))
   }
 

--- a/javaagent-core/build.gradle.kts
+++ b/javaagent-core/build.gradle.kts
@@ -9,5 +9,5 @@ dependencies {
     api("io.opentelemetry:opentelemetry-api:${versions["opentelemetry"]}")
     api("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions["opentelemetry"]}")
     implementation("org.slf4j:slf4j-api:${versions["slf4j"]}")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.16.0")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions["jackson"]}")
 }

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -5,6 +5,14 @@ plugins {
 }
 
 val versions: Map<String, String> by extra
+val jacksonVersion: String = versions["jackson"]!!
+
+configurations {
+    create("otelInstJacksonOverlay") {
+        isCanBeResolved = true
+        isCanBeConsumed = false
+    }
+}
 
 dependencies {
     // pin released version or snapshot with pinned version
@@ -13,6 +21,11 @@ dependencies {
     // https://dl.bintray.com/open-telemetry/maven/
     implementation("io.opentelemetry.javaagent", "opentelemetry-javaagent", version = "${versions["opentelemetry_java_agent_all"]}")
     implementation(project(":filter-api"))
+
+    add("otelInstJacksonOverlay", "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
+    add("otelInstJacksonOverlay", "com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
+    add("otelInstJacksonOverlay", "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+    add("otelInstJacksonOverlay", "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
 }
 
 base.archivesBaseName = "hypertrace-agent"
@@ -49,6 +62,14 @@ tasks.register<Copy>("extractOtelAgentJarInstClassdata") {
 
     from(zipTree(otelJavaAgentJar)) {
         include("inst/**")
+        // OTel ships Jackson 2.16.x in inst/; overlay with jacksonVersion after relocation
+        exclude("inst/com/fasterxml/**")
+        exclude("inst/org/yaml/**")
+        exclude("inst/META-INF/maven/com.fasterxml.jackson.core/**")
+        exclude("inst/META-INF/maven/com.fasterxml.jackson.dataformat/**")
+        exclude("inst/META-INF/maven/org.yaml/**")
+        exclude("inst/META-INF/versions/*/com/fasterxml/**")
+        exclude("inst/META-INF/versions/*/org/yaml/**")
         rename("(^.*)\\.classdata$", "$1.class")
     }
 
@@ -84,10 +105,35 @@ tasks.register<Copy>("extractRelocatedOtelClasses") {
     into("$buildDir/tmp/relocated-otel-classes")
 }
 
+// Step 3c: Replace OTel's embedded Jackson with jacksonVersion
+tasks.register<Copy>("overlayOtelInstJackson") {
+    description = "Replaces OTel embedded Jackson/SnakeYAML in inst/ with $jacksonVersion"
+
+    dependsOn("extractRelocatedOtelClasses")
+
+    val overlayJars = configurations["otelInstJacksonOverlay"].files
+
+    overlayJars.forEach { jar ->
+        from(zipTree(jar)) {
+            include("com/fasterxml/**")
+            include("org/yaml/**")
+            include("META-INF/maven/com.fasterxml.jackson.core/**")
+            include("META-INF/maven/com.fasterxml.jackson.dataformat/**")
+            include("META-INF/maven/org.yaml/**")
+            include("META-INF/versions/**/com/fasterxml/**")
+            include("META-INF/versions/**/org/yaml/**")
+            exclude("**/module-info.class")
+        }
+    }
+
+    into("$buildDir/tmp/relocated-otel-classes/inst/org/hypertrace")
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 tasks.register("extractOtelInstrumentationToInst") {
     description = "Removes empty directories from the relocated classes directory"
 
-    dependsOn("extractRelocatedOtelClasses")
+    dependsOn("overlayOtelInstJackson")
 
     doLast {
         // Find and delete empty directories

--- a/otel-extensions/build.gradle.kts
+++ b/otel-extensions/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
     api("com.google.protobuf:protobuf-java")
     api("com.google.protobuf:protobuf-java-util")
     // convert yaml to json, since java protobuf impl supports only json
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.16.0")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions["jackson"]}")
     // fix vulnerability
     constraints {
         api("com.google.code.gson:gson:2.8.9")

--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies{
     testImplementation("com.google.protobuf:protobuf-java-util:3.25.5")
     testImplementation("org.spockframework:spock-core:1.3-groovy-2.5")
     testImplementation("info.solidsoft.spock:spock-global-unroll:0.5.1")
-    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.16.0")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind:${versions["jackson"]}")
     testImplementation("org.codehaus.groovy:groovy-all:2.5.11")
     testImplementation("io.opentelemetry.semconv:opentelemetry-semconv:${versions["opentelemetry_semconv"]}")
 }


### PR DESCRIPTION
Upgrading vulnerable `jackson-databind` dependency coming from otel javaagent JAR